### PR TITLE
feat(path_generator): publish hazard signal (#252)

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -54,6 +54,8 @@ PathGenerator::PathGenerator(const rclcpp::NodeOptions & node_options)
   turn_signal_publisher_ =
     create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators_cmd", 1);
 
+  hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
+
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
 
   const auto params = param_listener_->get_params();
@@ -84,6 +86,11 @@ void PathGenerator::run()
     vehicle_info_.max_longitudinal_offset_m);
   turn_signal.stamp = now();
   turn_signal_publisher_->publish(turn_signal);
+
+  HazardLightsCommand hazard_signal;
+  hazard_signal.command = HazardLightsCommand::NO_COMMAND;
+  hazard_signal.stamp = now();
+  hazard_signal_publisher_->publish(hazard_signal);
 
   path_publisher_->publish(*path);
 }

--- a/planning/autoware_path_generator/src/node.hpp
+++ b/planning/autoware_path_generator/src/node.hpp
@@ -25,6 +25,7 @@
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -36,6 +37,7 @@ using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using nav_msgs::msg::Odometry;
 using ::path_generator::Params;
@@ -67,6 +69,7 @@ private:
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr path_publisher_;
   rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr turn_signal_publisher_;
+  rclcpp::Publisher<HazardLightsCommand>::SharedPtr hazard_signal_publisher_;
 
   rclcpp::TimerBase::SharedPtr timer_;
 


### PR DESCRIPTION
publish hazard signal (no command)

## Description


- ウィンカートピック名のリマップ忘れを修正。
- ハザードトピックを出力

cherr-pick 

https://github.com/autowarefoundation/autoware.core/pull/252

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

test with main psim
> Psim (The warning The operation mode is changed, but the HazardLightsCommand is not received yet is no longer showing up)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
