### PR TITLE
fix(path_generator): fix path bound generation (#267)

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -137,7 +137,7 @@ std::optional<double> get_first_self_intersection_arc_length(
   const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
 
 /**
- * @brief get bound of path cropped within specified range
+ * @brief get path bound for PathWithLaneId cropped within specified range
  * @param lanelet_bound original bound of lanelet
  * @param lanelet_centerline centerline of lanelet
  * @param s_start longitudinal distance of start of bound
@@ -145,7 +145,7 @@ std::optional<double> get_first_self_intersection_arc_length(
  * @return cropped bound
  */
 std::vector<geometry_msgs::msg::Point> get_path_bound(
-  const lanelet::CompoundLineString2d & lanelet_bound,
+  const lanelet::CompoundLineString3d & lanelet_bound,
   const lanelet::CompoundLineString2d & lanelet_centerline, const double s_start,
   const double s_end);
 

--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -259,20 +259,19 @@ std::vector<std::pair<lanelet::ConstPoints3d, std::pair<double, double>>> get_wa
 }
 
 std::vector<geometry_msgs::msg::Point> get_path_bound(
-  const lanelet::CompoundLineString2d & lanelet_bound,
+  const lanelet::CompoundLineString3d & lanelet_bound,
   const lanelet::CompoundLineString2d & lanelet_centerline, const double s_start,
   const double s_end)
 {
-  const auto path_start_point =
-    lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_start);
-  const auto path_end_point =
-    lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_end);
-
-  auto s_bound_start =
+  const auto lanelet_bound_2d = lanelet::utils::to2D(lanelet_bound);
+  const auto s_bound_start =
     lanelet::geometry::toArcCoordinates(
-      lanelet::utils::to2D(lanelet_bound.lineStrings().front()), path_start_point)
+      lanelet_bound_2d, lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_start))
       .length;
-  auto s_bound_end = lanelet::geometry::toArcCoordinates(lanelet_bound, path_end_point).length;
+  const auto s_bound_end =
+    lanelet::geometry::toArcCoordinates(
+      lanelet_bound_2d, lanelet::geometry::interpolatedPointAtDistance(lanelet_centerline, s_end))
+      .length;
 
   std::vector<geometry_msgs::msg::Point> path_bound{};
   auto s = 0.;
@@ -286,8 +285,7 @@ std::vector<geometry_msgs::msg::Point> get_path_bound(
     if (path_bound.empty()) {
       const auto interpolated_point =
         lanelet::geometry::interpolatedPointAtDistance(lanelet_bound, s_bound_start);
-      path_bound.push_back(
-        lanelet::utils::conversion::toGeomMsgPt(lanelet::utils::to3D(interpolated_point)));
+      path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(interpolated_point));
     } else {
       path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(*it));
     }
@@ -295,8 +293,7 @@ std::vector<geometry_msgs::msg::Point> get_path_bound(
     if (s >= s_bound_end) {
       const auto interpolated_point =
         lanelet::geometry::interpolatedPointAtDistance(lanelet_bound, s_bound_end);
-      path_bound.push_back(
-        lanelet::utils::conversion::toGeomMsgPt(lanelet::utils::to3D(interpolated_point)));
+      path_bound.push_back(lanelet::utils::conversion::toGeomMsgPt(interpolated_point));
       break;
     }
   }


### PR DESCRIPTION
## Description

x1リリース評価見つかった課題のhotfix 
https://github.com/autowarefoundation/autoware.core/pull/267

https://star4.slack.com/archives/C017VB9UG1L/p1741751660607219?thread_ts=1741578171.146089&cid=C017VB9UG1L

> レーンの区切りにゴールを置いた際に前方レーンにdriavable areaを拡張できずにスタックするようでした。
ゴール後のレーンも使用してdriavable areaを拡張するように修正しました

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim/evaluator in main
betaでの確認はしていないです :bow:

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
