### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): fix for mishandling lateral-distance 

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -259,7 +259,8 @@ VelocityPlanningResult ObstacleStopModule::plan(
 
 std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_to_stop_points(
   const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
-  const VehicleInfo & vehicle_info, size_t ego_idx)
+  const std::vector<Polygon2d> & decimated_traj_polys, const VehicleInfo & vehicle_info,
+  size_t ego_idx)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -285,14 +286,28 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
     for (const auto & index : cluster_indices.indices) {
       const auto obstacle_point = autoware::motion_velocity_planner::utils::to_geometry_point(
         filtered_points_ptr->points[index]);
+      // 1. brief filtering - filters out point-cloud points that are far from the trajectory
+      // laterally The lateral distance of the obstacle-point to trajectory is measured below
       const auto current_lat_dist_from_obstacle_to_traj =
         autoware::motion_utils::calcLateralOffset(traj_points, obstacle_point);
+      // The minimum lateral distance to the trajectory polygon is estimated by assuming that the
+      // ego-vehicle is fully perpendicular to the trajectory, in the very worst case
       const auto min_lat_dist_to_traj_poly =
-        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
-
+        std::abs(current_lat_dist_from_obstacle_to_traj) - vehicle_info.max_longitudinal_offset_m;
+      // The trajectory polygon is ignored if the minimum lateral distance is more than maximum
+      // lateral margin
       if (min_lat_dist_to_traj_poly >= p.max_lat_margin) {
         continue;
       }
+
+      // 2. precise filtering
+      const double precise_min_lat_dist_to_traj_poly =
+        utils::get_dist_to_traj_poly(obstacle_point, decimated_traj_polys);
+
+      if (precise_min_lat_dist_to_traj_poly >= obstacle_filtering_param_.max_lat_margin) {
+        continue;
+      }
+
       const auto current_ego_to_obstacle_distance =
         autoware::motion_velocity_planner::utils::calc_distance_to_front_object(
           traj_points, ego_idx, obstacle_point);
@@ -436,13 +451,13 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
 
   const auto & tp = trajectory_polygon_collision_check;
 
-  const std::vector<geometry_msgs::msg::Point> stop_points =
-    convert_point_cloud_to_stop_points(point_cloud, traj_points, vehicle_info, ego_idx);
-
   // calculated decimated trajectory points and trajectory polygon
   const auto decimated_traj_polys = polygon_utils::create_one_step_polygons(
     decimated_traj_points, vehicle_info, odometry.pose.pose, 0.0,
     tp.enable_to_consider_current_pose, tp.time_to_convergence, tp.decimate_trajectory_step_length);
+
+  const std::vector<geometry_msgs::msg::Point> stop_points = convert_point_cloud_to_stop_points(
+    point_cloud, traj_points, decimated_traj_polys, vehicle_info, ego_idx);
 
   debug_data_ptr_->decimated_traj_polys = decimated_traj_polys;
 
@@ -471,17 +486,26 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
 
     const auto lat_dist_from_obstacle_to_traj =
       autoware::motion_utils::calcLateralOffset(traj_points, itr->collision_point);
-    const auto min_lat_dist_to_traj_poly =
-      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.vehicle_width_m;
+    const double min_lat_dist_to_traj_poly =
+      std::abs(lat_dist_from_obstacle_to_traj) - vehicle_info.max_longitudinal_offset_m;
 
-    if (min_lat_dist_to_traj_poly < obstacle_filtering_param_.max_lat_margin) {
-      auto stop_obstacle = *itr;
-      stop_obstacle.dist_to_collide_on_decimated_traj =
-        autoware::motion_utils::calcSignedArcLength(
-          decimated_traj_points, 0, stop_obstacle.collision_point) -
-        dist_to_bumper;
-      past_stop_obstacles.push_back(stop_obstacle);
+    if (min_lat_dist_to_traj_poly >= obstacle_filtering_param_.max_lat_margin) {
+      continue;
     }
+
+    const double precise_min_lat_dist_to_traj_poly =
+      utils::get_dist_to_traj_poly(itr->collision_point, decimated_traj_polys);
+
+    if (precise_min_lat_dist_to_traj_poly >= obstacle_filtering_param_.max_lat_margin) {
+      continue;
+    }
+
+    auto stop_obstacle = *itr;
+    stop_obstacle.dist_to_collide_on_decimated_traj =
+      autoware::motion_utils::calcSignedArcLength(
+        decimated_traj_points, 0, stop_obstacle.collision_point) -
+      dist_to_bumper;
+    past_stop_obstacles.push_back(stop_obstacle);
 
     ++itr;
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -100,7 +100,8 @@ private:
 
   std::vector<geometry_msgs::msg::Point> convert_point_cloud_to_stop_points(
     const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
-    const VehicleInfo & vehicle_info, size_t ego_idx);
+    const std::vector<Polygon2d> & decimated_traj_polys, const VehicleInfo & vehicle_info,
+    size_t ego_idx);
 
   std::vector<Polygon2d> get_trajectory_polygon_for_inside(
     const std::vector<TrajectoryPoint> & decimated_traj_points, const VehicleInfo & vehicle_info,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -143,6 +143,9 @@ size_t get_index_with_longitudinal_offset(
 double calc_possible_min_dist_from_obj_to_traj_poly(
   const std::shared_ptr<PlannerData::Object> object,
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
-}  // namespace autoware::motion_velocity_planner::utils
 
+double get_dist_to_traj_poly(
+  const geometry_msgs::msg::Point & point,
+  const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys);
+}  // namespace autoware::motion_velocity_planner::utils
 #endif  // AUTOWARE__MOTION_VELOCITY_PLANNER_COMMON__UTILS_HPP_

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/geometry.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
@@ -200,4 +201,23 @@ double calc_possible_min_dist_from_obj_to_traj_poly(
     object_possible_max_dist;
   return possible_min_dist_to_traj_poly;
 }
+
+double get_dist_to_traj_poly(
+  const geometry_msgs::msg::Point & point,
+  const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys)
+{
+  const auto point_2d = autoware_utils_geometry::Point2d(point.x, point.y);
+
+  double dist_to_traj_poly = std::numeric_limits<double>::infinity();
+
+  for (const auto & decimated_traj_poly : decimated_traj_polys) {
+    const double current_dist_to_traj_poly =
+      boost::geometry::distance(decimated_traj_poly, point_2d);
+
+    dist_to_traj_poly = std::min(dist_to_traj_poly, current_dist_to_traj_poly);
+  }
+
+  return dist_to_traj_poly;
+}
+
 }  // namespace autoware::motion_velocity_planner::utils


### PR DESCRIPTION
## Description

Pointcloud clusters too far from the footprint of the vehicle are considered to be obstructive and slow-down and stop modules are triggered unnecessarily.
This PR is for the core changes.

## Related links

**Parent Issue:**

https://tier4.atlassian.net/browse/RT1-10023

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
