### PR TITLE
fix(behavior_velocity_planner): validate extedned line (#527)

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -520,19 +520,20 @@ LineString2d extendSegmentToBounds(
       [](const auto & point) { return Point2d{point.x(), point.y()}; });
     return autoware_line_string;
   };
+  const auto original_line = to_autoware_line_string(segment);
 
   if (segment.size() != 2) {
     std::cerr << "[behavior_velocity](extendLineStringUntilIntersection) input segment must "
                  "have exactly 2 points"
               << std::endl;
-    return to_autoware_line_string(segment);
+    return original_line;
   }
 
   if (bound1.size() < 2 || bound2.size() < 2) {
     std::cerr << "[behavior_velocity](extendLineStringUntilIntersection) input bounds must "
                  "have at least 2 points"
               << std::endl;
-    return to_autoware_line_string(segment);
+    return original_line;
   }
 
   const auto find_intersection_point =
@@ -568,13 +569,32 @@ LineString2d extendSegmentToBounds(
   const auto intersection2 = find_intersection_point(bound2);
 
   if (!intersection1 || !intersection2) {
-    return to_autoware_line_string(segment);
+    return original_line;
   }
 
-  if ((*intersection2 - *intersection1).dot(segment[1] - segment[0]) < 0.0) {
-    return LineString2d{*intersection2, *intersection1};
+  // verify if extended and original segments have overlapping parts
+  const auto extended = (*intersection2 - *intersection1).dot(segment[1] - segment[0]) < 0.0
+                          ? LineString2d{*intersection2, *intersection1}
+                          : LineString2d{*intersection1, *intersection2};
+  const auto original_points =
+    std::array{Point2d{segment[0].x(), segment[0].y()}, Point2d{segment[1].x(), segment[1].y()}};
+  const auto extended_points = std::array{extended[0], extended[1]};
+  constexpr double containment_threshold = 0.1;
+  const auto is_point_on_line = [](const LineString2d & line, const Point2d & point) {
+    return boost::geometry::distance(point, line) < containment_threshold;
+  };
+  const auto has_overlap =
+    std::any_of(
+      original_points.begin(), original_points.end(),
+      [&](const auto & point) { return is_point_on_line(extended, point); }) ||
+    std::any_of(extended_points.begin(), extended_points.end(), [&](const auto & point) {
+      return is_point_on_line(original_line, point);
+    });
+  if (!has_overlap) {
+    return original_line;
   }
-  return LineString2d{*intersection1, *intersection2};
+
+  return extended;
 }
 
 std::optional<int64_t> getNearestLaneId(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_util.cpp
@@ -356,6 +356,42 @@ TEST(PlanningUtilsTest, ExtendSegmentToBounds)
     EXPECT_NEAR(result[1].x(), segment[1].x(), epsilon);
     EXPECT_NEAR(result[1].y(), segment[1].y(), epsilon);
   }
+
+  {  // extended segment has no overlap with original segment
+    const lanelet::BasicLineString2d segment{{0.0, 1.0}, {0.0, -1.0}};
+
+    const auto bound1_excluding_segment = make_bound({-1.0, 2.0}, {1.0, 2.0});
+    const auto bound2_excluding_segment = make_bound({-1.0, 3.0}, {1.0, 3.0});
+
+    const auto result =
+      extendSegmentToBounds(segment, bound1_excluding_segment, bound2_excluding_segment);
+
+    ASSERT_EQ(result.size(), 2);
+
+    // Check the output segment coordinates (should be original segment)
+    EXPECT_NEAR(result[0].x(), segment[0].x(), epsilon);
+    EXPECT_NEAR(result[0].y(), segment[0].y(), epsilon);
+    EXPECT_NEAR(result[1].x(), segment[1].x(), epsilon);
+    EXPECT_NEAR(result[1].y(), segment[1].y(), epsilon);
+  }
+
+  {  // extended segment has no overlap with original segment (negative y direction)
+    const lanelet::BasicLineString2d segment{{0.0, 1.0}, {0.0, -1.0}};
+
+    const auto bound1_excluding_segment = make_bound({-1.0, -2.0}, {1.0, -2.0});
+    const auto bound2_excluding_segment = make_bound({-1.0, -3.0}, {1.0, -3.0});
+
+    const auto result =
+      extendSegmentToBounds(segment, bound1_excluding_segment, bound2_excluding_segment);
+
+    ASSERT_EQ(result.size(), 2);
+
+    // Check the output segment coordinates (should be original segment)
+    EXPECT_NEAR(result[0].x(), segment[0].x(), epsilon);
+    EXPECT_NEAR(result[0].y(), segment[0].y(), epsilon);
+    EXPECT_NEAR(result[1].x(), segment[1].x(), epsilon);
+    EXPECT_NEAR(result[1].y(), segment[1].y(), epsilon);
+  }
 }
 
 TEST(PlanningUtilsTest, getConstLaneletsFromIds)


### PR DESCRIPTION
## Description

xx1で見つかった停止線がおかしい場所に出る問題へのhotfix
https://github.com/autowarefoundation/autoware_core/pull/527 の取り込み

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/5b13afb6-1f34-5255-aedb-b73f2d3a88fa?project_id=prd_jt
3949/3949

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
