### PR TITLE
feat(default_adapi): backport adapi v1.9.0

### DIFF
--- a/api/autoware_default_adapi/src/interface.cpp
+++ b/api/autoware_default_adapi/src/interface.cpp
@@ -24,7 +24,7 @@ InterfaceNode::InterfaceNode(const rclcpp::NodeOptions & options)
     [this](
       const Version::Service::Request::SharedPtr, const Version::Service::Response::SharedPtr res) {
       res->major = 1;
-      res->minor = 8;
+      res->minor = 9;
       res->patch = 0;
     }))
 {

--- a/api/autoware_default_adapi/test/node/interface_version.py
+++ b/api/autoware_default_adapi/test/node/interface_version.py
@@ -30,7 +30,7 @@ response = future.result()
 
 if response.major != 1:
     exit(1)
-if response.minor != 8:
+if response.minor != 9:
     exit(1)
 if response.patch != 0:
     exit(1)


### PR DESCRIPTION
## Description

AD API のバージョン更新がリリースに入っていなかったので取り込みお願いします。

## Related links

https://github.com/autowarefoundation/autoware_core/pull/550

## How was this PR tested?

```
$ ros2 service call /api/interface/version autoware_adapi_version_msgs/srv/InterfaceVersion 
requester: making request: autoware_adapi_version_msgs.srv.InterfaceVersion_Request()

response:
autoware_adapi_version_msgs.srv.InterfaceVersion_Response(major=1, minor=9, patch=0)
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
