### PR TITLE
feat: change planning output topic name to /planning/trajectory (#602)

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
@@ -67,7 +67,7 @@ struct LaneletRoute
 struct Trajectory
 {
   using Message = autoware_planning_msgs::msg::Trajectory;
-  static constexpr char name[] = "/planning/scenario_planning/trajectory";
+  static constexpr char name[] = "/planning/trajectory";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;

--- a/common/autoware_motion_utils/docs/vehicle/vehicle.md
+++ b/common/autoware_motion_utils/docs/vehicle/vehicle.md
@@ -83,10 +83,10 @@ This class check whether the vehicle arrive at stop point based on localization 
 
 #### Subscribed Topics
 
-| Name                                     | Type                                      | Description      |
-| ---------------------------------------- | ----------------------------------------- | ---------------- |
-| `/localization/kinematic_state`          | `nav_msgs::msg::Odometry`                 | vehicle odometry |
-| `/planning/scenario_planning/trajectory` | `autoware_planning_msgs::msg::Trajectory` | trajectory       |
+| Name                            | Type                                      | Description      |
+| ------------------------------- | ----------------------------------------- | ---------------- |
+| `/localization/kinematic_state` | `nav_msgs::msg::Odometry`                 | vehicle odometry |
+| `/planning/trajectory`          | `autoware_planning_msgs::msg::Trajectory` | trajectory       |
 
 #### Parameters
 

--- a/common/autoware_motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/autoware_motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -103,7 +103,7 @@ VehicleArrivalChecker::VehicleArrivalChecker(rclcpp::Node * node) : VehicleStopC
   using std::placeholders::_1;
 
   sub_trajectory_ = node->create_subscription<Trajectory>(
-    "/planning/scenario_planning/trajectory", rclcpp::QoS(1),
+    "/planning/trajectory", rclcpp::QoS(1),
     std::bind(&VehicleArrivalChecker::onTrajectory, this, _1));
 }
 

--- a/common/autoware_motion_utils/test/src/vehicle/test_vehicle_state_checker.cpp
+++ b/common/autoware_motion_utils/test/src/vehicle/test_vehicle_state_checker.cpp
@@ -58,7 +58,7 @@ public:
   PubManager() : Node("test_pub_node")
   {
     pub_odom_ = create_publisher<Odometry>("/localization/kinematic_state", 1);
-    pub_traj_ = create_publisher<Trajectory>("/planning/scenario_planning/trajectory", 1);
+    pub_traj_ = create_publisher<Trajectory>("/planning/trajectory", 1);
   }
 
   rclcpp::Publisher<Odometry>::SharedPtr pub_odom_;

--- a/control/autoware_core_control/launch/autoware_core_control.launch.xml
+++ b/control/autoware_core_control/launch/autoware_core_control.launch.xml
@@ -8,7 +8,7 @@
       <param from="$(var vehicle_info_param_file)"/>
 
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-      <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
+      <remap from="~/input/trajectory" to="/planning/trajectory"/>
       <remap from="~/output/control_command" to="/control/command/control_cmd"/>
     </node>
   </group>

--- a/control/autoware_simple_pure_pursuit/launch/simple_pure_pursuit.launch.xml
+++ b/control/autoware_simple_pure_pursuit/launch/simple_pure_pursuit.launch.xml
@@ -6,7 +6,7 @@
     <param from="$(var vehicle_info_param_file)"/>
 
     <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-    <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
+    <remap from="~/input/trajectory" to="/planning/trajectory"/>
     <remap from="~/output/control_command" to="/control/trajectory_follower/control_cmd"/>
   </node>
 </launch>

--- a/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
+++ b/planning/autoware_core_planning/launch/autoware_core_planning.launch.xml
@@ -130,7 +130,7 @@
 
       <param name="publish_debug_trajs" value="false"/>
       <remap from="~/input/trajectory" to="/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/trajectory"/>
-      <remap from="~/output/trajectory" to="/planning/scenario_planning/trajectory"/>
+      <remap from="~/output/trajectory" to="/planning/trajectory"/>
 
       <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
       <remap from="~/input/acceleration" to="/localization/acceleration"/>

--- a/planning/autoware_velocity_smoother/launch/velocity_smoother.launch.xml
+++ b/planning/autoware_velocity_smoother/launch/velocity_smoother.launch.xml
@@ -5,7 +5,7 @@
 
   <!-- input/output -->
   <arg name="input_trajectory" default="/planning/scenario_planning/scenario_selector/trajectory"/>
-  <arg name="output_trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="output_trajectory" default="/planning/trajectory"/>
 
   <!-- debug flags -->
   <arg name="publish_debug_trajs" default="false"/>

--- a/testing/autoware_test_utils/rviz/psim_test_map.rviz
+++ b/testing/autoware_test_utils/rviz/psim_test_map.rviz
@@ -1010,7 +1010,7 @@ Visualization Manager:
                 Filter size: 10
                 History Policy: Keep Last
                 Reliability Policy: Reliable
-                Value: /planning/scenario_planning/trajectory
+                Value: /planning/trajectory
               Value: true
               View Footprint:
                 Alpha: 1


### PR DESCRIPTION
## Description

Cherry-pick from https://github.com/autowarefoundation/autoware_core/pull/602

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
