### PR TITLE
fix(autoware_mission_planner, velocity_smoother): use transient_local for operation_mode_state

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -61,7 +61,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   sub_odometry_ = create_subscription<Odometry>(
     "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlanner::on_odometry, this, _1));
   sub_operation_mode_state_ = create_subscription<OperationModeState>(
-    "~/input/operation_mode_state", rclcpp::QoS(1),
+    "~/input/operation_mode_state", rclcpp::QoS(1).transient_local(),
     std::bind(&MissionPlanner::on_operation_mode_state, this, _1));
   sub_vector_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", durable_qos, std::bind(&MissionPlanner::on_map, this, _1));

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -96,7 +96,7 @@ private:
     VelocityLimit, autoware_utils_rclcpp::polling_policy::Newest>
     sub_external_velocity_limit_{this, "~/input/external_velocity_limit_mps"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
-    this, "~/input/operation_mode_state"};
+    this, "~/input/operation_mode_state", rclcpp::QoS{1}.transient_local()};
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
   AccelWithCovarianceStamped::ConstSharedPtr current_acceleration_ptr_;


### PR DESCRIPTION
Cherry-picked from https://github.com/autowarefoundation/autoware_core/pull/598

https://star4.slack.com/archives/C07GU9S7NVC/p1755752797551849?thread_ts=1755731134.154809&cid=C07GU9S7NVC

シナリオテストで
```
Simulation error [AutowareError]: Simulator waited for the Autoware state to transition to WAITING_FOR_ENGAGE, but time is up. The current Autoware state is PLANNING
```


/system/operation_mode/stateのpublishタイミングによっては、サブスクライバーが取りこぼす場合がありました。
trasient_localに変更することで対応。

https://github.com/tier4/autoware_universe/pull/2324

## テスト

before
- https://evaluation.tier4.jp/evaluation/reports/2341cc2d-b806-5000-8ca3-f130546fb634/?project_id=prd_jt
  - 3859 / 3903

after
tmp/test_random_fail_v0.48
- https://evaluation.ci.tier4.jp/evaluation/reports/9e347204-3c3d-5c34-88b8-5b08cafb1da5?project_id=prd_jt
  - 3969/3987
  - state遷移のfail無し。