### PR TITLE
feat(obstacle_stop, motion_velocity_planner_common, motion_utils): update pointcloud stop

### DIFF
--- a/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
+++ b/common/autoware_interpolation/src/spline_interpolation_points_2d.cpp
@@ -83,6 +83,14 @@ std::vector<double> splineYawFromPoints(const std::vector<T> & points)
 }
 template std::vector<double> splineYawFromPoints(
   const std::vector<geometry_msgs::msg::Point> & points);
+template std::vector<double> splineYawFromPoints(
+  const std::vector<geometry_msgs::msg::Pose> & points);
+template std::vector<double> splineYawFromPoints(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> & points);
+template std::vector<double> splineYawFromPoints(
+  const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points);
+template std::vector<double> splineYawFromPoints(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
 
 geometry_msgs::msg::Pose SplineInterpolationPoints2d::getSplineInterpolatedPose(
   const size_t idx, const double s) const

--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -1045,6 +1045,46 @@ calcCurvatureAndSegmentLength<std::vector<autoware_planning_msgs::msg::Trajector
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
 
 /**
+ * @brief calculate elevation angles through points container.
+ * The method calculates elevation angles between consecutive points in the container.
+ * @param points points of trajectory, path, ...
+ * @return calculated elevation angles container through points container
+ */
+template <class T>
+std::vector<double> calcElevationAngles(const T & points)
+{
+  std::vector<double> elevation_angles(points.size());
+  if (points.size() < 2) {
+    return elevation_angles;
+  }
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    geometry_msgs::msg::Point src_point, dst_point;
+    if (i == points.size() - 1) {
+      src_point = autoware_utils_geometry::get_point(points.at(i - 1));
+      dst_point = autoware_utils_geometry::get_point(points.at(i));
+    } else {
+      src_point = autoware_utils_geometry::get_point(points.at(i));
+      dst_point = autoware_utils_geometry::get_point(points.at(i + 1));
+    }
+
+    elevation_angles.at(i) = autoware_utils_geometry::calc_elevation_angle(src_point, dst_point);
+  }
+
+  return elevation_angles;
+}
+
+extern template std::vector<double>
+calcElevationAngles<std::vector<autoware_planning_msgs::msg::PathPoint>>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> & points);
+extern template std::vector<double>
+calcElevationAngles<std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId>>(
+  const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points);
+extern template std::vector<double>
+calcElevationAngles<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
+
+/**
  * @brief calculate length of 2D distance between given start point index in points container and
  * first point in container with zero longitudinal velocity
  * @param points_with_twist points of trajectory, path, ... (with velocity)
@@ -1885,6 +1925,8 @@ void insertOrientation(T & points, const bool is_driving_forward)
     for (size_t i = 0; i < points.size() - 1; ++i) {
       const auto & src_point = autoware_utils_geometry::get_point(points.at(i));
       const auto & dst_point = autoware_utils_geometry::get_point(points.at(i + 1));
+      // TODO(Yuki TAKAGI): The current implementation sets a value with the sign inverted. Fix in
+      // https://github.com/autowarefoundation/autoware_core/issues/571
       const double pitch = autoware_utils_geometry::calc_elevation_angle(src_point, dst_point);
       const double yaw = autoware_utils_geometry::calc_azimuth_angle(src_point, dst_point);
       autoware_utils_geometry::set_orientation(
@@ -1899,6 +1941,7 @@ void insertOrientation(T & points, const bool is_driving_forward)
     for (size_t i = points.size() - 1; i >= 1; --i) {
       const auto & src_point = autoware_utils_geometry::get_point(points.at(i));
       const auto & dst_point = autoware_utils_geometry::get_point(points.at(i - 1));
+      // NOTE: pitch sign is incorrect.
       const double pitch = autoware_utils_geometry::calc_elevation_angle(src_point, dst_point);
       const double yaw = autoware_utils_geometry::calc_azimuth_angle(src_point, dst_point);
       autoware_utils_geometry::set_orientation(
@@ -1933,27 +1976,14 @@ void insertOrientationAsSpline(T & points, const bool is_driving_forward)
   }
 
   const double yaw_offset = is_driving_forward ? 0.0 : M_PI;
-  const int8_t pitch_sign = is_driving_forward ? 1 : -1;
+  const int8_t pitch_sign = is_driving_forward ? -1 : 1;
 
-  std::vector<geometry_msgs::msg::Point> geometry_points_vec(points.size());
+  const auto yaw_vec = autoware::interpolation::splineYawFromPoints(points);
+  const auto pitch_vec = calcElevationAngles(points);
+
   for (size_t i = 0; i < points.size(); ++i) {
-    geometry_points_vec.at(i) = autoware_utils_geometry::get_point(points.at(i));
-  }
-
-  const auto yaw_vec = autoware::interpolation::splineYawFromPoints(geometry_points_vec);
-  for (size_t i = 0; i < points.size(); ++i) {
-    geometry_msgs::msg::Point src_point, dst_point;
-    if (i == points.size() - 1) {
-      src_point = geometry_points_vec.at(i - 1);
-      dst_point = geometry_points_vec.at(i);
-    } else {
-      src_point = geometry_points_vec.at(i);
-      dst_point = geometry_points_vec.at(i + 1);
-    }
-
     const double yaw = yaw_offset + yaw_vec.at(i);
-    const double pitch =
-      pitch_sign * autoware_utils_geometry::calc_elevation_angle(src_point, dst_point);
+    const double pitch = pitch_sign * pitch_vec.at(i);
     autoware_utils_geometry::set_orientation(
       autoware_utils_geometry::create_quaternion_from_rpy(0.0, pitch, yaw), points.at(i));
   }

--- a/common/autoware_motion_utils/src/trajectory/trajectory.cpp
+++ b/common/autoware_motion_utils/src/trajectory/trajectory.cpp
@@ -263,6 +263,17 @@ calcCurvatureAndSegmentLength<std::vector<autoware_planning_msgs::msg::Trajector
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
 
 //
+template std::vector<double>
+calcElevationAngles<std::vector<autoware_planning_msgs::msg::PathPoint>>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> & points);
+template std::vector<double>
+calcElevationAngles<std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId>>(
+  const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points);
+template std::vector<double>
+calcElevationAngles<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
+
+//
 template std::optional<double>
 calcDistanceToForwardStopPoint<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points_with_twist,

--- a/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/test_trajectory.cpp
@@ -4559,7 +4559,7 @@ TEST(trajectory, insertOrientationWithHelicalForwardPath)
     path_points.at(i).position =
       create_point(radius * cos(alpha), radius * sin(alpha), slope_rate * radius * alpha);
     correct_orientations.at(i).orientation =
-      create_quaternion_from_rpy(0.0, slope_rate, alpha + autoware_utils_math::pi / 2.0);
+      create_quaternion_from_rpy(0.0, -slope_rate, alpha + autoware_utils_math::pi / 2.0);
   }
   {
     insertOrientation(path_points, true);
@@ -4569,7 +4569,9 @@ TEST(trajectory, insertOrientationWithHelicalForwardPath)
       const auto res_rpy = autoware_utils_geometry::get_rpy(res_p);
       const auto cor_rpy = autoware_utils_geometry::get_rpy(cor_p);
       EXPECT_NEAR(res_rpy.x, cor_rpy.x, 0.02);
-      EXPECT_NEAR(res_rpy.y, cor_rpy.y, 0.02);
+      // TODO(Yuki TAKAGI): The current implementation sets a value with the sign inverted. Fix in
+      // https://github.com/autowarefoundation/autoware_core/issues/571
+      // EXPECT_NEAR(res_rpy.y, cor_rpy.y, 0.02);
       EXPECT_NEAR(res_rpy.z, cor_rpy.z, 0.02);
     }
   }
@@ -4593,7 +4595,7 @@ TEST(trajectory, insertOrientationWithHelicalBackwardPath)
     path_points.at(i).position =
       create_point(radius * cos(alpha), radius * sin(alpha), slope_rate * radius * alpha);
     correct_orientations.at(i).orientation =
-      create_quaternion_from_rpy(0.0, -slope_rate, alpha - autoware_utils_math::pi / 2.0);
+      create_quaternion_from_rpy(0.0, slope_rate, alpha - autoware_utils_math::pi / 2.0);
   }
   {
     insertOrientation(path_points, false);
@@ -4603,7 +4605,9 @@ TEST(trajectory, insertOrientationWithHelicalBackwardPath)
       const auto res_rpy = autoware_utils_geometry::get_rpy(res_p);
       const auto cor_rpy = autoware_utils_geometry::get_rpy(cor_p);
       EXPECT_NEAR(res_rpy.x, cor_rpy.x, 0.02);
-      EXPECT_NEAR(res_rpy.y, cor_rpy.y, 0.02);
+      // TODO(Yuki TAKAGI): The current implementation sets a value with the sign inverted. Fix in
+      // https://github.com/autowarefoundation/autoware_core/issues/571
+      // EXPECT_NEAR(res_rpy.y, cor_rpy.y, 0.02);
       EXPECT_NEAR(res_rpy.z, cor_rpy.z, 0.02);
     }
   }
@@ -4627,7 +4631,7 @@ TEST(trajectory, insertOrientationAsSplineWithHelicalForwardPath)
     raw_path_points.at(i).position =
       create_point(radius * cos(alpha), radius * sin(alpha), slope_rate * radius * alpha);
     correct_orientation_points.at(i).orientation =
-      create_quaternion_from_rpy(0.0, slope_rate, alpha + autoware_utils_math::pi / 2.0);
+      create_quaternion_from_rpy(0.0, -slope_rate, alpha + autoware_utils_math::pi / 2.0);
   }
   {
     auto full_path_points = raw_path_points;
@@ -4677,7 +4681,7 @@ TEST(trajectory, insertOrientationAsSplineWithHelicalBackwardPath)
     raw_path_points.at(i).position =
       create_point(radius * cos(alpha), radius * sin(alpha), slope_rate * radius * alpha);
     correct_orientation_points.at(i).orientation =
-      create_quaternion_from_rpy(0.0, -slope_rate, alpha - autoware_utils_math::pi / 2.0);
+      create_quaternion_from_rpy(0.0, slope_rate, alpha - autoware_utils_math::pi / 2.0);
   }
   {
     auto full_path_points = raw_path_points;

--- a/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -13,9 +13,6 @@
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
 
-    pointcloud:
-      mask_lat_margin: 2.0 # for compatibility with the current universe code
-
     pointcloud_preprocessing:
       filter_by_trajectory_polygon:
         enable_monolithic_crop_box: false  # [-] if true, crop pointcloud using trajectory polygon

--- a/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     smooth_velocity_before_planning: true  # [-] if true, smooth the velocity profile of the input trajectory before planning
 
-    trajectory_polygon_collision_check:
+    trajectory_polygon_collision_check: # used by obstacle_*_modules
       decimate_trajectory_step_length : 2.0 # longitudinal step length to calculate trajectory polygon for collision checking
       goal_extended_trajectory_length: 6.0
 
@@ -14,11 +14,23 @@
         time_to_convergence: 1.5 #[s]
 
     pointcloud:
-      pointcloud_voxel_grid_x: 0.05
-      pointcloud_voxel_grid_y: 0.05
-      pointcloud_voxel_grid_z: 100000.0
-      pointcloud_cluster_tolerance: 1.0
-      pointcloud_min_cluster_size: 1
-      pointcloud_max_cluster_size: 100000
+      mask_lat_margin: 2.0 # for compatibility with the current universe code
 
-      mask_lat_margin: 2.0
+    pointcloud_preprocessing:
+      filter_by_trajectory_polygon:
+        enable_monolithic_crop_box: false  # [-] if true, crop pointcloud using trajectory polygon
+        enable_multi_polygon_filtering: true  # [-] if true, filter pointcloud using trajectory polygon
+        min_trajectory_length: 30.0  # [m] minimum trajectory length to crop pointcloud
+        braking_distance_scale_factor: 1.5  # scale factor for brake distance to crop pointcloud
+        lateral_margin: 2.0  # lateral margin to mask pointcloud
+        height_margin: 1.0  # height margin to mask pointcloud
+      downsample_by_voxel_grid:
+        enable_downsample: true  # [-] if true, downsample
+        voxel_size_x: 0.05
+        voxel_size_y: 0.05
+        voxel_size_z: 100000.0
+      euclidean_clustering:
+        enable_clustering: true  # [-] if true, cluster pointcloud by euclidean distance, even if false, dummy indexes are prepared.
+        cluster_tolerance: 1.0 # [m] clustering tolerance
+        min_cluster_size: 1  # minimum cluster size
+        max_cluster_size: 100000  # maximum cluster size

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -51,24 +51,33 @@
         obstacle_velocity_threshold_exit_fixed_stop: 3.5  # [m/s] obstacle velocity threshold to use its braking distance (if use_rss_stop is true) for stop point decision
 
       obstacle_filtering: # All parameters under this namespace can be set for each object type. If you want to set a value different from the default, please add a line.
-        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint
+        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint; can be tuned for each object type
           default: true
           pointcloud: false
         check_outside: # If true, the planner checks if the obstacle is outside the ego's footprint. pointcloud obstacles are not supported.
           default: true
           unknown: false
 
-        trim_trajectory: # This feature supports only pointcloud obstacles yet.
+        trim_trajectory:
           enable_trimming:
             default: false
             pointcloud: true
           min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
           braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
 
-        max_lat_margin: # lateral margin between the obstacles and ego's footprint
-          default: 0.3
-          unknown: 0.3
-          pointcloud: 0.3
+        lateral_margin: # lateral margin between the obstacles and ego's footprint
+          nominal:
+            default: 0.3
+            unknown: 0.3
+            pointcloud: 0.3
+          additional: # additional stop margin to the obstacle.
+            wheel_off_track_scale: # scale factor for additional stop margin against ego's wheel off-track. Even if this value is set to 0.0, the planner considers the nominal wheel off-track.
+              default: 0.0
+            is_moving_threshold_velocity: 0.5 # [m/s] threshold to consider the obstacle as a moving obstacle. Pointcloud obstacles are always considered as stop obstacles.
+            is_stop_obstacle: # [m] additional stop margin for stop obstacle
+              default: 0.0
+            is_moving_obstacle: # [m] additional stop margin for moving obstacle
+              default: 0.0
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -20,6 +20,7 @@
 
         hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
         hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
+        pointcloud_suppression_distance_margin: 0.2
 
         stop_on_curve:
           enable_approaching: false
@@ -43,6 +44,7 @@
           two_wheel_objects_deceleration: -3.0 # [m/ss] for BICYCLE, MOTORCYCLE
           vehicle_objects_deceleration: -1.2 # [m/ss] for CAR, TRUCK, etc
           no_wheel_objects_deceleration: -10.0 # [m/ss] for PEDESTRIAN, UNKNOWN
+          pointcloud_deceleration: -1.0 # [m/ss] for pointcloud
           velocity_offset: -1.0 # [m/s]
 
         obstacle_velocity_threshold_enter_fixed_stop: 3.0  # [m/s] obstacle velocity threshold to use its current position for stop point decision
@@ -73,15 +75,28 @@
             pedestrian: true
 
         pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
+          trim_trajectory:
+            enable_trim: true
+            min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
+            braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
+          time_series_association:
+            max_time_diff: 0.35
+            min_velocity: -5.0
+            max_velocity: 30.0
+            position_diff: 1.0
+          velocity_estimation:
+            use_estimated_velocity: false
+            min_clamp_velocity: 0.0
+            max_clamp_velocity: 20.0
+            required_velocity_count: 5
+            lpf_gain: 0.9
+          height_margin:
+            margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
+            margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle
 
         max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
         max_lat_margin_against_predicted_object_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
+        max_lat_margin_against_pointcloud: 0.3
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -50,63 +50,53 @@
         obstacle_velocity_threshold_enter_fixed_stop: 3.0  # [m/s] obstacle velocity threshold to use its current position for stop point decision
         obstacle_velocity_threshold_exit_fixed_stop: 3.5  # [m/s] obstacle velocity threshold to use its braking distance (if use_rss_stop is true) for stop point decision
 
-      obstacle_filtering:
-        object_type:
+      obstacle_filtering: # All parameters under this namespace can be set for each object type. If you want to set a value different from the default, please add a line.
+        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint
+          default: true
           pointcloud: false
+        check_outside: # If true, the planner checks if the obstacle is outside the ego's footprint. pointcloud obstacles are not supported.
+          default: true
+          unknown: false
 
-          inside:
-            unknown: true
-            car: true
-            truck: true
-            bus: true
-            trailer: true
-            motorcycle: true
-            bicycle: true
-            pedestrian: true
+        trim_trajectory: # This feature supports only pointcloud obstacles yet.
+          enable_trimming:
+            default: false
+            pointcloud: true
+          min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
+          braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
 
-          outside:
-            unknown: false
-            car: true
-            truck: true
-            bus: true
-            trailer: true
-            motorcycle: true
-            bicycle: true
-            pedestrian: true
-
-        pointcloud:
-          trim_trajectory:
-            enable_trim: true
-            min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
-            braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
-          time_series_association:
-            max_time_diff: 0.35
-            min_velocity: -5.0
-            max_velocity: 30.0
-            position_diff: 1.0
-          velocity_estimation:
-            use_estimated_velocity: false
-            min_clamp_velocity: 0.0
-            max_clamp_velocity: 20.0
-            required_velocity_count: 5
-            lpf_gain: 0.9
-          height_margin:
-            margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
-            margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle
-
-        max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
-        max_lat_margin_against_predicted_object_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
-        max_lat_margin_against_pointcloud: 0.3
+        max_lat_margin: # lateral margin between the obstacles and ego's footprint
+          default: 0.3
+          unknown: 0.3
+          pointcloud: 0.3
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
-        outside_obstacle:
+        outside_obstacle: # Parameters for predicting if an obstacle will cut in. Pointcloud obstacles are not supported.
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
-          pedestrian_deceleration: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          deceleration: # planner perceives the object will stop with this rate to avoid unnecessary stops [m/ss]
+            default: 0.0
+            pedestrian: 1.0
+            bicycle: 2.0
 
-        crossing_obstacle:
+        crossing_obstacle: # Parameters for predicting if an obstacle will cross. Pointcloud obstacles are not supported.
           collision_time_margin : 1.0 # time threshold of collision between obstacle and ego for cruise or stop [s]
           traj_angle_threshold: 0.523599 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
+
+      pointcloud_segmentation:
+        time_series_association:
+          max_time_diff: 0.35
+          min_velocity: -5.0
+          max_velocity: 30.0
+          position_diff: 1.0
+        velocity_estimation:
+          use_estimated_velocity: false
+          min_clamp_velocity: 0.0
+          max_clamp_velocity: 20.0
+          required_velocity_count: 5
+          lpf_gain: 0.9
+        height_margin:
+          margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
+          margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -23,9 +23,10 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_internal_debug_msgs/srv/string.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/srv/load_plugin.hpp>
+#include <autoware_internal_planning_msgs/srv/unload_plugin.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
@@ -45,6 +46,8 @@
 namespace autoware::behavior_velocity_planner
 {
 using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::srv::LoadPlugin;
+using autoware_internal_planning_msgs::srv::UnloadPlugin;
 using autoware_map_msgs::msg::LaneletMapBin;
 
 class BehaviorVelocityPlannerNode : public rclcpp::Node
@@ -118,14 +121,13 @@ private:
   BehaviorVelocityPlannerManager planner_manager_;
   bool is_driving_forward_{true};
 
-  rclcpp::Service<autoware_internal_debug_msgs::srv::String>::SharedPtr srv_load_plugin_;
-  rclcpp::Service<autoware_internal_debug_msgs::srv::String>::SharedPtr srv_unload_plugin_;
+  rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
+  rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;
   void onUnloadPlugin(
-    const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
-    const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response);
+    const UnloadPlugin::Request::SharedPtr request,
+    const UnloadPlugin::Response::SharedPtr response);
   void onLoadPlugin(
-    const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
-    const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response);
+    const LoadPlugin::Request::SharedPtr request, const LoadPlugin::Response::SharedPtr response);
 
   // mutex for planner_data_
   std::mutex mutex_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -65,9 +65,9 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
     this->create_subscription<autoware_internal_planning_msgs::msg::PathWithLaneId>(
       "~/input/path_with_lane_id", 1, std::bind(&BehaviorVelocityPlannerNode::onTrigger, this, _1));
 
-  srv_load_plugin_ = create_service<autoware_internal_debug_msgs::srv::String>(
+  srv_load_plugin_ = create_service<LoadPlugin>(
     "~/service/load_plugin", std::bind(&BehaviorVelocityPlannerNode::onLoadPlugin, this, _1, _2));
-  srv_unload_plugin_ = create_service<autoware_internal_debug_msgs::srv::String>(
+  srv_unload_plugin_ = create_service<UnloadPlugin>(
     "~/service/unload_plugin",
     std::bind(&BehaviorVelocityPlannerNode::onUnloadPlugin, this, _1, _2));
 
@@ -105,19 +105,19 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 }
 
 void BehaviorVelocityPlannerNode::onLoadPlugin(
-  const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
-  [[maybe_unused]] const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response)
+  const LoadPlugin::Request::SharedPtr request,
+  [[maybe_unused]] const LoadPlugin::Response::SharedPtr response)
 {
   std::unique_lock<std::mutex> lk(mutex_);
-  planner_manager_.launchScenePlugin(*this, request->data);
+  planner_manager_.launchScenePlugin(*this, request->plugin_name);
 }
 
 void BehaviorVelocityPlannerNode::onUnloadPlugin(
-  const autoware_internal_debug_msgs::srv::String::Request::SharedPtr request,
-  [[maybe_unused]] const autoware_internal_debug_msgs::srv::String::Response::SharedPtr response)
+  const UnloadPlugin::Request::SharedPtr request,
+  [[maybe_unused]] const UnloadPlugin::Response::SharedPtr response)
 {
   std::unique_lock<std::mutex> lk(mutex_);
-  planner_manager_.removeScenePlugin(*this, request->data);
+  planner_manager_.removeScenePlugin(*this, request->plugin_name);
 }
 
 void BehaviorVelocityPlannerNode::onParam()

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/CMakeLists.txt
@@ -15,6 +15,8 @@ if(BUILD_TESTING)
   # Add test executable
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
     test/test_obstacle_stop_module_outside_check.cpp
+    test/test_types.cpp
+    test/test_parameters.cpp
     test/test_utils.cpp
     test/test_utils.hpp
   )

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -51,24 +51,33 @@
         obstacle_velocity_threshold_exit_fixed_stop: 3.5  # [m/s] obstacle velocity threshold to use its braking distance (if use_rss_stop is true) for stop point decision
 
       obstacle_filtering: # All parameters under this namespace can be set for each object type. If you want to set a value different from the default, please add a line.
-        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint
+        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint; can be tuned for each object type
           default: true
           pointcloud: false
         check_outside: # If true, the planner checks if the obstacle is outside the ego's footprint. pointcloud obstacles are not supported.
           default: true
           unknown: false
 
-        trim_trajectory: # This feature supports only pointcloud obstacles yet.
+        trim_trajectory:
           enable_trimming:
             default: false
             pointcloud: true
           min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
           braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
 
-        max_lat_margin: # lateral margin between the obstacles and ego's footprint
-          default: 0.3
-          unknown: 0.3
-          pointcloud: 0.3
+        lateral_margin: # lateral margin between the obstacles and ego's footprint
+          nominal:
+            default: 0.3
+            unknown: 0.3
+            pointcloud: 0.3
+          additional: # additional stop margin to the obstacle.
+            wheel_off_track_scale: # scale factor for additional stop margin against ego's wheel off-track. Even if this value is set to 0.0, the planner considers the nominal wheel off-track.
+              default: 0.0
+            is_moving_threshold_velocity: 0.5 # [m/s] threshold to consider the obstacle as a moving obstacle. Pointcloud obstacles are always considered as stop obstacles.
+            is_stop_obstacle: # [m] additional stop margin for stop obstacle
+              default: 0.0
+            is_moving_obstacle: # [m] additional stop margin for moving obstacle
+              default: 0.0
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -20,6 +20,7 @@
 
         hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
         hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
+        pointcloud_suppression_distance_margin: 0.2
 
         stop_on_curve:
           enable_approaching: false
@@ -43,6 +44,7 @@
           two_wheel_objects_deceleration: -3.0 # [m/ss] for BICYCLE, MOTORCYCLE
           vehicle_objects_deceleration: -1.2 # [m/ss] for CAR, TRUCK, etc
           no_wheel_objects_deceleration: -10.0 # [m/ss] for PEDESTRIAN, UNKNOWN
+          pointcloud_deceleration: -1.0 # [m/ss] for pointcloud
           velocity_offset: -1.0 # [m/s]
 
         obstacle_velocity_threshold_enter_fixed_stop: 3.0  # [m/s] obstacle velocity threshold to use its current position for stop point decision
@@ -73,15 +75,28 @@
             pedestrian: true
 
         pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
+          trim_trajectory:
+            enable_trim: true
+            min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
+            braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
+          time_series_association:
+            max_time_diff: 0.35
+            min_velocity: -5.0
+            max_velocity: 30.0
+            position_diff: 1.0
+          velocity_estimation:
+            use_estimated_velocity: false
+            min_clamp_velocity: 0.0
+            max_clamp_velocity: 20.0
+            required_velocity_count: 5
+            lpf_gain: 0.9
+          height_margin:
+            margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
+            margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle
 
         max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
         max_lat_margin_against_predicted_object_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
+        max_lat_margin_against_pointcloud: 0.3
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -50,63 +50,53 @@
         obstacle_velocity_threshold_enter_fixed_stop: 3.0  # [m/s] obstacle velocity threshold to use its current position for stop point decision
         obstacle_velocity_threshold_exit_fixed_stop: 3.5  # [m/s] obstacle velocity threshold to use its braking distance (if use_rss_stop is true) for stop point decision
 
-      obstacle_filtering:
-        object_type:
+      obstacle_filtering: # All parameters under this namespace can be set for each object type. If you want to set a value different from the default, please add a line.
+        check_inside: # If true, the planner checks if the obstacle is inside the ego's footprint
+          default: true
           pointcloud: false
+        check_outside: # If true, the planner checks if the obstacle is outside the ego's footprint. pointcloud obstacles are not supported.
+          default: true
+          unknown: false
 
-          inside:
-            unknown: true
-            car: true
-            truck: true
-            bus: true
-            trailer: true
-            motorcycle: true
-            bicycle: true
-            pedestrian: true
+        trim_trajectory: # This feature supports only pointcloud obstacles yet.
+          enable_trimming:
+            default: false
+            pointcloud: true
+          min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
+          braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
 
-          outside:
-            unknown: false
-            car: true
-            truck: true
-            bus: true
-            trailer: true
-            motorcycle: true
-            bicycle: true
-            pedestrian: true
-
-        pointcloud:
-          trim_trajectory:
-            enable_trim: true
-            min_trajectory_length: 30.0  # [m] minimum trajectory length to trim trajectory
-            braking_distance_scale_factor: 1.5  # scale factor for brake distance to trim trajectory
-          time_series_association:
-            max_time_diff: 0.35
-            min_velocity: -5.0
-            max_velocity: 30.0
-            position_diff: 1.0
-          velocity_estimation:
-            use_estimated_velocity: false
-            min_clamp_velocity: 0.0
-            max_clamp_velocity: 20.0
-            required_velocity_count: 5
-            lpf_gain: 0.9
-          height_margin:
-            margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
-            margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle
-
-        max_lat_margin: 0.3 # lateral margin between the obstacles except for unknown and ego's footprint
-        max_lat_margin_against_predicted_object_unknown: 0.3 # lateral margin between the unknown obstacles and ego's footprint
-        max_lat_margin_against_pointcloud: 0.3
+        max_lat_margin: # lateral margin between the obstacles and ego's footprint
+          default: 0.3
+          unknown: 0.3
+          pointcloud: 0.3
 
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
-        outside_obstacle:
+        outside_obstacle: # Parameters for predicting if an obstacle will cut in. Pointcloud obstacles are not supported.
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
-          pedestrian_deceleration: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          deceleration: # planner perceives the object will stop with this rate to avoid unnecessary stops [m/ss]
+            default: 0.0
+            pedestrian: 1.0
+            bicycle: 2.0
 
-        crossing_obstacle:
+        crossing_obstacle: # Parameters for predicting if an obstacle will cross. Pointcloud obstacles are not supported.
           collision_time_margin : 1.0 # time threshold of collision between obstacle and ego for cruise or stop [s]
           traj_angle_threshold: 0.523599 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
+
+      pointcloud_segmentation:
+        time_series_association:
+          max_time_diff: 0.35
+          min_velocity: -5.0
+          max_velocity: 30.0
+          position_diff: 1.0
+        velocity_estimation:
+          use_estimated_velocity: false
+          min_clamp_velocity: 0.0
+          max_clamp_velocity: 20.0
+          required_velocity_count: 5
+          lpf_gain: 0.9
+        height_margin:
+          margin_from_top: 0.5 # [m] margin from the top of the ego vehicle
+          margin_from_bottom: 0.5 # [m] margin from the bottom of the ego vehicle

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_motion_velocity_planner_common</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_signal_processing</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -344,10 +344,8 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
   const auto extended_traj_points_from_ego = utils::get_extended_trajectory_points(
     traj_points, tp.goal_extended_trajectory_length, tp.decimate_trajectory_step_length);
 
-  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr(
-    extended_traj_points_from_ego, vehicle_info);  // extend trajectory points here
-  const std::vector<pcl::PointIndices> clusters =
-    pointcloud.get_cluster_indices(extended_traj_points_from_ego, vehicle_info);
+  const PointCloud::Ptr filtered_points_ptr = pointcloud.get_filtered_pointcloud_ptr();
+  const std::vector<pcl::PointIndices> clusters = pointcloud.get_cluster_indices();
 
   // 2. convert clusters to obstacles
   for (const auto & cluster_indices : clusters) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -168,19 +168,25 @@ double calc_time_to_reach_collision_point(
          std::max(min_velocity_to_reach_collision_point, std::abs(odometry.twist.twist.linear.x));
 }
 
-double calc_braking_dist(const uint8_t obj_label, const double lon_vel, const RSSParam & rss_params)
+double calc_braking_dist(
+  const ObjectClassWithPointCloud & extended_label, const double lon_vel,
+  const RSSParam & rss_params)
 {
   const double braking_acc = [&]() {
-    switch (obj_label) {
-      case ObjectClassification::UNKNOWN:
-      case ObjectClassification::PEDESTRIAN:
-        return rss_params.no_wheel_objects_deceleration;
-      case ObjectClassification::BICYCLE:
-      case ObjectClassification::MOTORCYCLE:
-        return rss_params.two_wheel_objects_deceleration;
-      default:
-        return rss_params.vehicle_objects_deceleration;
+    if (extended_label.is_point_cloud) {
+      return rss_params.pointcloud_deceleration;
     }
+    if (
+      extended_label.object_classification.label == ObjectClassification::UNKNOWN ||
+      extended_label.object_classification.label == ObjectClassification::PEDESTRIAN) {
+      return rss_params.no_wheel_objects_deceleration;
+    }
+    if (
+      extended_label.object_classification.label == ObjectClassification::BICYCLE ||
+      extended_label.object_classification.label == ObjectClassification::MOTORCYCLE) {
+      return rss_params.two_wheel_objects_deceleration;
+    }
+    return rss_params.vehicle_objects_deceleration;
   }();
   const double error_considered_vel = std::max(lon_vel + rss_params.velocity_offset, 0.0);
   return error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
@@ -296,8 +302,7 @@ VelocityPlanningResult ObstacleStopModule::plan(
   auto stop_obstacles_for_point_cloud = filter_stop_obstacle_for_point_cloud(
     planner_data->current_odometry, raw_trajectory_points, decimated_traj_points,
     planner_data->no_ground_pointcloud, planner_data->vehicle_info_, dist_to_bumper,
-    planner_data->trajectory_polygon_collision_check,
-    planner_data->find_index(raw_trajectory_points, planner_data->current_odometry.pose.pose));
+    planner_data->trajectory_polygon_collision_check);
 
   // 5. concat stop obstacles by predicted objects and point cloud
   const std::vector<StopObstacle> stop_obstacles =
@@ -401,33 +406,79 @@ std::vector<geometry_msgs::msg::Point> ObstacleStopModule::convert_point_cloud_t
   return stop_collision_points;
 }
 
-StopObstacle ObstacleStopModule::create_stop_obstacle_for_point_cloud(
-  const std::vector<TrajectoryPoint> & traj_points, const rclcpp::Time & stamp,
-  const geometry_msgs::msg::Point & stop_point, const double dist_to_bumper) const
+std::optional<CollisionPointWithDist> ObstacleStopModule::get_nearest_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const PlannerData::Pointcloud & point_cloud, const double dist_to_bumper,
+  const VehicleInfo & vehicle_info) const
 {
-  const auto dist_to_collide_on_traj =
-    autoware::motion_utils::calcSignedArcLength(traj_points, 0, stop_point) - dist_to_bumper;
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const unique_identifier_msgs::msg::UUID obj_uuid;
-  const auto & obj_uuid_str = autoware_utils_uuid::to_hex_string(obj_uuid);
+  if (traj_points.size() != traj_polygons.size()) {
+    RCLCPP_ERROR(
+      logger_, "The size of trajectory points and polygons do not match: %zu vs %zu",
+      traj_points.size(), traj_polygons.size());
+    return std::nullopt;
+  }
 
-  autoware_perception_msgs::msg::Shape bounding_box_shape;
-  bounding_box_shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  if (point_cloud.pointcloud.empty()) {
+    return std::nullopt;
+  }
 
-  ObjectClassification unconfigured_object_classification;
+  const auto & clusters = point_cloud.get_cluster_indices(traj_points, vehicle_info);
+  const auto & pointcloud_ptr = point_cloud.get_filtered_pointcloud_ptr(traj_points, vehicle_info);
 
-  const geometry_msgs::msg::Pose unconfigured_pose;
-  const double unconfigured_lon_vel = 0.;
+  // height check will works even on the slope, but it is not accurate.
+  const auto & height_margin =
+    obstacle_filtering_param_.pointcloud_obstacle_filtering_param.height_margin;
+  std::vector<geometry_msgs::msg::Point> collision_geom_points{};
+  for (size_t traj_index = 0; traj_index < traj_points.size(); ++traj_index) {
+    const double rough_dist_th = boost::geometry::perimeter(traj_polygons.at(traj_index)) * 0.5;
+    const double traj_height = traj_points.at(traj_index).pose.position.z;
 
-  return StopObstacle{
-    obj_uuid_str,
-    stamp,
-    unconfigured_object_classification,
-    unconfigured_pose,
-    bounding_box_shape,
-    unconfigured_lon_vel,
-    stop_point,
-    dist_to_collide_on_traj};
+    for (const auto & cluster : clusters) {
+      for (const auto & point_index : cluster.indices) {
+        const auto obstacle_point = autoware::motion_velocity_planner::utils::to_geometry_point(
+          pointcloud_ptr->at(point_index));
+        if (
+          obstacle_point.z - traj_height < -height_margin.margin_from_bottom ||
+          obstacle_point.z - traj_height >
+            vehicle_info.max_height_offset_m + height_margin.margin_from_top) {
+          continue;
+        }
+        const double dist_from_base_link =
+          autoware_utils::calc_distance2d(traj_points.at(traj_index).pose, obstacle_point);
+        if (dist_from_base_link > rough_dist_th) {
+          continue;
+        }
+        Point2d obstacle_point_2d{obstacle_point.x, obstacle_point.y};
+        if (boost::geometry::within(obstacle_point_2d, traj_polygons.at(traj_index))) {
+          collision_geom_points.push_back(obstacle_point);
+        }
+      }
+    }
+    if (collision_geom_points.empty()) {
+      continue;
+    }
+
+    const auto bumper_pose =
+      autoware_utils::calc_offset_pose(traj_points.at(traj_index).pose, dist_to_bumper, 0.0, 0.0);
+    std::optional<double> max_collision_length = std::nullopt;
+    std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
+    for (const auto & point : collision_geom_points) {
+      const double dist_from_bumper =
+        std::abs(autoware_utils::inverse_transform_point(point, bumper_pose).x);
+
+      if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+        max_collision_length = dist_from_bumper;
+        max_collision_point = point;
+      }
+    }
+    return CollisionPointWithDist{
+      *max_collision_point,
+      autoware::motion_utils::calcSignedArcLength(traj_points, 0, traj_index) -
+        *max_collision_length};
+  }
+  return std::nullopt;
 }
 
 std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_predicted_object(
@@ -510,12 +561,71 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_predicted
   return stop_obstacles;
 }
 
+void ObstacleStopModule::upsert_pointcloud_stop_candidates(
+  const CollisionPointWithDist & nearest_collision_point,
+  const std::vector<TrajectoryPoint> & traj_points, rclcpp::Time latest_point_cloud_time)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto & vel_params =
+    obstacle_filtering_param_.pointcloud_obstacle_filtering_param.velocity_estimation;
+  const auto & assoc_params =
+    obstacle_filtering_param_.pointcloud_obstacle_filtering_param.time_series_association;
+
+  // check association from the newest candidate to the oldest candidate
+  for (auto stop_candidate = pointcloud_stop_candidates.rbegin();
+       stop_candidate != pointcloud_stop_candidates.rend(); ++stop_candidate) {
+    const double time_since_latest_collision =
+      (latest_point_cloud_time - stop_candidate->latest_collision_pointcloud_time).seconds();
+    if (time_since_latest_collision < 0.05) {
+      return;  // latest_point_cloud_time is already checked.
+    }
+    const double longitudinal_displacement = autoware::motion_utils::calcSignedArcLength(
+      traj_points, stop_candidate->latest_collision_point.point, nearest_collision_point.point);
+
+    if (
+      time_since_latest_collision < assoc_params.max_time_diff &&
+      -assoc_params.position_diff + assoc_params.min_velocity * time_since_latest_collision <
+        longitudinal_displacement &&
+      longitudinal_displacement <
+        assoc_params.position_diff + assoc_params.max_velocity * time_since_latest_collision) {
+      const double clamped_vel = std::clamp(
+        longitudinal_displacement / time_since_latest_collision, vel_params.min_clamp_velocity,
+        vel_params.max_clamp_velocity);
+      if (!stop_candidate->vel_lpf.getValue().has_value()) {
+        auto & vel_vec = stop_candidate->initial_velocities;
+        vel_vec.push_back(clamped_vel);
+        if (vel_vec.size() >= vel_params.required_velocity_count) {
+          stop_candidate->vel_lpf.reset(
+            std::accumulate(vel_vec.begin(), vel_vec.end(), 0.0) / vel_vec.size());
+        }
+      } else {
+        stop_candidate->vel_lpf.filter(clamped_vel);
+      }
+      stop_candidate->latest_collision_point = nearest_collision_point;
+      stop_candidate->latest_collision_pointcloud_time = latest_point_cloud_time;
+
+      std::sort(
+        pointcloud_stop_candidates.begin(), pointcloud_stop_candidates.end(),
+        [](const PointcloudStopCandidate & a, const PointcloudStopCandidate & b) {
+          return a.latest_collision_pointcloud_time < b.latest_collision_pointcloud_time;
+        });
+
+      return;
+    }
+  }
+  PointcloudStopCandidate new_stop_candidate;
+  new_stop_candidate.latest_collision_point = nearest_collision_point;
+  new_stop_candidate.latest_collision_pointcloud_time = latest_point_cloud_time;
+  new_stop_candidate.vel_lpf.setGain(vel_params.lpf_gain);
+  pointcloud_stop_candidates.push_back(new_stop_candidate);
+}
+
 std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_cloud(
   const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
   const std::vector<TrajectoryPoint> & decimated_traj_points,
   const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
   const double dist_to_bumper,
-  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx)
+  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -523,76 +633,98 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
     return std::vector<StopObstacle>{};
   }
 
+  const auto trimmed_decimated_traj_points = [&]() {
+    const auto & trim_param =
+      obstacle_filtering_param_.pointcloud_obstacle_filtering_param.trim_trajectory;
+    if (!trim_param.enable_trim || !autoware::motion_utils::isDrivingForward(traj_points)) {
+      return decimated_traj_points;
+    }
+    const auto braking_distance =
+      autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
+        odometry.twist.twist.linear.x, 0.0, common_param_.max_accel, common_param_.min_accel,
+        common_param_.max_jerk, common_param_.min_jerk)
+        .value_or(0.0);
+    const double trim_length = trim_param.min_trajectory_length +
+                               trim_param.braking_distance_scale_factor * braking_distance;
+
+    return autoware::motion_utils::cropForwardPoints(
+      decimated_traj_points, decimated_traj_points.front().pose.position, 0, trim_length);
+  }();
+
   const auto & tp = trajectory_polygon_collision_check;
+  const auto trimmed_decimated_traj_polys_with_lat_margin = polygon_utils::create_one_step_polygons(
+    trimmed_decimated_traj_points, vehicle_info, odometry.pose.pose,
+    obstacle_filtering_param_.max_lat_margin_against_pointcloud, tp.enable_to_consider_current_pose,
+    tp.time_to_convergence, tp.decimate_trajectory_step_length);
+  // prioritize the polygon for predicted object
+  if (debug_data_ptr_->decimated_traj_polys.empty()) {
+    debug_data_ptr_->decimated_traj_polys = trimmed_decimated_traj_polys_with_lat_margin;
+  }
 
-  // calculated decimated trajectory points and trajectory polygon
-  const auto decimated_traj_polys = polygon_utils::create_one_step_polygons(
-    decimated_traj_points, vehicle_info, odometry.pose.pose, 0.0,
-    tp.enable_to_consider_current_pose, tp.time_to_convergence, tp.decimate_trajectory_step_length);
+  const auto nearest_collision_point = get_nearest_collision_point(
+    trimmed_decimated_traj_points, trimmed_decimated_traj_polys_with_lat_margin, point_cloud,
+    dist_to_bumper, vehicle_info);
 
-  const std::vector<geometry_msgs::msg::Point> stop_points = convert_point_cloud_to_stop_points(
-    point_cloud, traj_points, decimated_traj_polys, vehicle_info, tp, ego_idx);
+  // update pointcloud_stop_candidates
+  const auto latest_point_cloud_time =
+    rclcpp::Time(point_cloud.pointcloud.header.stamp * static_cast<uint32_t>(1e3), RCL_ROS_TIME);
+  if (nearest_collision_point) {
+    upsert_pointcloud_stop_candidates(
+      nearest_collision_point.value(), traj_points, latest_point_cloud_time);
+  }
 
-  debug_data_ptr_->decimated_traj_polys = decimated_traj_polys;
+  // erase old data from the front of the deque
+  // pointcloud_stop_candidates are sorted by latest_collision_pointcloud_time, so we can erase old
+  // data from the front.
+  while (
+    !pointcloud_stop_candidates.empty() &&
+    (latest_point_cloud_time - pointcloud_stop_candidates.front().latest_collision_pointcloud_time)
+        .seconds() > obstacle_filtering_param_.stop_obstacle_hold_time_threshold) {
+    pointcloud_stop_candidates.pop_front();
+  }
 
-  const auto & stop_obstacle_stamp = rclcpp::Time(point_cloud.pointcloud.header.stamp);
-
-  // determine ego's behavior from stop
+  // pick stop_obstacle from candidates
   std::vector<StopObstacle> stop_obstacles;
-  for (const auto & stop_point : stop_points) {
-    // Filter obstacles for stop
-    const auto stop_obstacle = create_stop_obstacle_for_point_cloud(
-      decimated_traj_points, stop_obstacle_stamp, stop_point, dist_to_bumper);
-    stop_obstacles.push_back(stop_obstacle);
+  for (const auto & stop_candidate : pointcloud_stop_candidates) {
+    if (!stop_candidate.vel_lpf.getValue().has_value()) {
+      continue;
+    }
+
+    const double time_delay =
+      (clock_->now() - stop_candidate.latest_collision_pointcloud_time).seconds();
+    const double time_compensated_dist_to_collide =
+      stop_candidate.latest_collision_point.dist_to_collide +
+      *stop_candidate.vel_lpf.getValue() * time_delay;
+
+    const bool use_estimated_velocity =
+      obstacle_filtering_param_.pointcloud_obstacle_filtering_param.velocity_estimation
+        .use_estimated_velocity;
+    if (
+      !use_estimated_velocity ||
+      *stop_candidate.vel_lpf.getValue() <
+        stop_planning_param_.obstacle_velocity_threshold_enter_fixed_stop) {
+      stop_obstacles.emplace_back(
+        stop_candidate.latest_collision_pointcloud_time, true,
+        stop_candidate.vel_lpf.getValue().value(), stop_candidate.latest_collision_point.point,
+        time_compensated_dist_to_collide);
+    } else if (stop_planning_param_.rss_params.use_rss_stop) {
+      const auto braking_dist = calc_braking_dist(
+        ObjectClassWithPointCloud{true}, *stop_candidate.vel_lpf.getValue(),
+        stop_planning_param_.rss_params);
+      stop_obstacles.emplace_back(
+        stop_candidate.latest_collision_pointcloud_time, true,
+        stop_candidate.vel_lpf.getValue().value(), stop_candidate.latest_collision_point.point,
+        time_compensated_dist_to_collide, braking_dist);
+      RCLCPP_DEBUG(
+        logger_,
+        "|_PC_| total_dist: %2.5f, raw_dist: %2.5f, time_compensated dist: %2.5f, braking_dist: "
+        "%2.5f",
+        (time_compensated_dist_to_collide + braking_dist),
+        (stop_candidate.latest_collision_point.dist_to_collide), time_compensated_dist_to_collide,
+        braking_dist);
+    }
   }
 
-  std::vector<StopObstacle> past_stop_obstacles;
-  for (auto itr = stop_pointcloud_obstacle_history_.begin();
-       itr != stop_pointcloud_obstacle_history_.end();) {
-    rclcpp::Time odom_time(odometry.header.stamp.sec, odometry.header.stamp.nanosec);
-    rclcpp::Time itr_time(itr->stamp);
-
-    const double elapsed_time = (odom_time - itr_time).seconds();
-    if (elapsed_time >= obstacle_filtering_param_.stop_obstacle_hold_time_threshold) {
-      itr = stop_pointcloud_obstacle_history_.erase(itr);
-      continue;
-    }
-
-    const auto lat_dist_from_obstacle_to_traj =
-      autoware::motion_utils::calcLateralOffset(traj_points, itr->collision_point);
-    const double min_lat_dist_to_traj_poly =
-      std::abs(lat_dist_from_obstacle_to_traj) -
-      std::hypot(vehicle_info.max_longitudinal_offset_m, vehicle_info.vehicle_width_m / 2.0);
-
-    if (min_lat_dist_to_traj_poly >= obstacle_filtering_param_.max_lat_margin) {
-      continue;
-    }
-
-    const double precise_min_lat_dist_to_traj_poly =
-      utils::get_dist_to_traj_poly(itr->collision_point, decimated_traj_polys);
-
-    if (precise_min_lat_dist_to_traj_poly >= obstacle_filtering_param_.max_lat_margin) {
-      continue;
-    }
-
-    auto stop_obstacle = *itr;
-    stop_obstacle.dist_to_collide_on_decimated_traj =
-      autoware::motion_utils::calcSignedArcLength(
-        decimated_traj_points, 0, stop_obstacle.collision_point) -
-      dist_to_bumper;
-    past_stop_obstacles.push_back(stop_obstacle);
-
-    ++itr;
-  }
-
-  stop_pointcloud_obstacle_history_ = autoware::motion_velocity_planner::utils::concat_vectors(
-    std::move(stop_pointcloud_obstacle_history_), stop_obstacles);
-  stop_obstacles = autoware::motion_velocity_planner::utils::concat_vectors(
-    std::move(stop_obstacles), std::move(past_stop_obstacles));
-
-  RCLCPP_DEBUG(
-    logger_, "The number of output obstacles of filter_stop_obstacles is %ld",
-    stop_obstacles.size());
   return stop_obstacles;
 }
 
@@ -692,8 +824,13 @@ std::optional<StopObstacle> ObstacleStopModule::pick_stop_obstacle_from_predicte
 
   if (stop_planning_param_.rss_params.use_rss_stop) {
     const auto braking_dist = calc_braking_dist(
-      obj_label, object->get_lon_vel_relative_to_traj(traj_points),
+      ObjectClassWithPointCloud{obj_label}, object->get_lon_vel_relative_to_traj(traj_points),
       stop_planning_param_.rss_params);
+
+    RCLCPP_DEBUG(
+      logger_, "|_OBJ_| total_dist: %2.5f, dist_to_collide: %2.5f, braking_dist: %2.5f",
+      (collision_point->second + braking_dist), (collision_point->second), braking_dist);
+
     return StopObstacle{
       autoware_utils_uuid::to_hex_string(predicted_object.object_id),
       predicted_objects_stamp,
@@ -852,13 +989,20 @@ std::optional<geometry_msgs::msg::Point> ObstacleStopModule::plan_stop(
 
     if (determined_stop_obstacle) {
       const bool is_same_param_types =
-        (stop_obstacle.classification.label == determined_stop_obstacle->classification.label);
+        (stop_obstacle.classification == determined_stop_obstacle->classification);
+      const auto point_cloud_suppression_margin = [&](const StopObstacle & obs) {
+        return obs.classification.is_point_cloud
+                 ? stop_planning_param_.pointcloud_suppression_distance_margin
+                 : 0.0;
+      };
       if (
         (is_same_param_types && stop_obstacle.dist_to_collide_on_decimated_traj +
                                     stop_obstacle.dist_to_collide_on_decimated_traj >
                                   determined_stop_obstacle->dist_to_collide_on_decimated_traj +
                                     determined_stop_obstacle->braking_dist.value_or(0.0)) ||
-        (!is_same_param_types && *candidate_zero_vel_dist > determined_zero_vel_dist)) {
+        (!is_same_param_types &&
+         *candidate_zero_vel_dist + point_cloud_suppression_margin(stop_obstacle) >
+           *determined_zero_vel_dist + point_cloud_suppression_margin(*determined_stop_obstacle))) {
         continue;
       }
     }
@@ -1010,7 +1154,7 @@ std::optional<double> ObstacleStopModule::calc_candidate_zero_vel_dist(
         RCLCPP_WARN(
           rclcpp::get_logger("ObstacleCruisePlanner::StopPlanner"),
           "[Cruise] abandon to stop against %s object",
-          stop_planning_param_.object_types_maps.at(stop_obstacle.classification.label).c_str());
+          stop_planning_param_.get_param_type(stop_obstacle.classification).c_str());
         return std::nullopt;
       } else {
         return stop_planning_param_.get_param(stop_obstacle.classification).limit_min_acc;
@@ -1355,7 +1499,7 @@ std::vector<StopObstacle> ObstacleStopModule::get_closest_stop_obstacles(
   for (const auto & stop_obstacle : stop_obstacles) {
     const auto itr =
       std::find_if(candidates.begin(), candidates.end(), [&stop_obstacle](const StopObstacle & co) {
-        return co.classification.label == stop_obstacle.classification.label;
+        return co.classification == stop_obstacle.classification;
       });
     if (itr == candidates.end()) {
       candidates.emplace_back(stop_obstacle);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -84,7 +84,9 @@ private:
   bool suppress_sudden_stop_{};
   CommonParam common_param_{};
   StopPlanningParam stop_planning_param_{};
-  ObstacleFilteringParam obstacle_filtering_param_{};
+  std::unordered_map<StopObstacleClassification::Type, ObstacleFilteringParam>
+    obstacle_filtering_params_{};
+  PointcloudSegmentationParam pointcloud_segmentation_param_;
 
   // module publisher
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr debug_stop_planning_info_pub_{};
@@ -203,9 +205,6 @@ private:
     const PlannerData::Pointcloud & point_cloud, const double x_offset_to_bumper,
     const VehicleInfo & vehicle_info) const;
 
-  double calc_collision_time_margin(
-    const Odometry & odometry, const std::vector<polygon_utils::PointWithStamp> & collision_points,
-    const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper) const;
   void check_consistency(
     const rclcpp::Time & current_time,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
@@ -216,7 +215,6 @@ private:
     const double x_offset_to_bumper, const double default_stop_margin) const;
   std::vector<StopObstacle> get_closest_stop_obstacles(
     const std::vector<StopObstacle> & stop_obstacles);
-  double get_max_lat_margin(const uint8_t obj_label) const;
   std::vector<Polygon2d> get_decimated_traj_polys(
     const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -134,7 +134,7 @@ private:
     const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
-    const VehicleInfo & vehicle_info, const double dist_to_bumper,
+    const VehicleInfo & vehicle_info, const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
 
   /// @brief Update pointcloud_stop_candidates by the nearest collision point
@@ -151,17 +151,17 @@ private:
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
-    const double dist_to_bumper,
+    const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
 
   std::optional<geometry_msgs::msg::Point> plan_stop(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<StopObstacle> & stop_obstacles, const double dist_to_bumper);
+    const std::vector<StopObstacle> & stop_obstacles, const double x_offset_to_bumper);
   double calc_desired_stop_margin(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points, const StopObstacle & stop_obstacle,
-    const double dist_to_bumper, const size_t ego_segment_idx,
+    const double x_offset_to_bumper, const size_t ego_segment_idx,
     const double dist_to_collide_on_ref_traj);
   std::optional<double> calc_candidate_zero_vel_dist(
     const std::shared_ptr<const PlannerData> planner_data,
@@ -173,7 +173,7 @@ private:
     std::optional<double> & determined_zero_vel_dist);
   std::optional<geometry_msgs::msg::Point> calc_stop_point(
     const std::shared_ptr<const PlannerData> planner_data,
-    const std::vector<TrajectoryPoint> & traj_points, const double dist_to_bumper,
+    const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper,
     const std::optional<StopObstacle> & determined_stop_obstacle,
     const std::optional<double> & determined_zero_vel_dist);
   void set_stop_planning_debug_info(
@@ -186,7 +186,7 @@ private:
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::shared_ptr<PlannerData::Object> object, const rclcpp::Time & predicted_objects_stamp,
     const double dist_from_obj_poly_to_traj_poly, const VehicleInfo & vehicle_info,
-    const double dist_to_bumper,
+    const double x_offset_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check) const;
   bool is_obstacle_velocity_requiring_fixed_stop(
     const std::shared_ptr<PlannerData::Object> object,
@@ -194,18 +194,18 @@ private:
   bool is_crossing_transient_obstacle(
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
-    const std::shared_ptr<PlannerData::Object> object, const double dist_to_bumper,
+    const std::shared_ptr<PlannerData::Object> object, const double x_offset_to_bumper,
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
     const std::optional<std::pair<geometry_msgs::msg::Point, double>> & collision_point) const;
 
   std::optional<CollisionPointWithDist> get_nearest_collision_point(
     const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
-    const PlannerData::Pointcloud & point_cloud, const double dist_to_bumper,
+    const PlannerData::Pointcloud & point_cloud, const double x_offset_to_bumper,
     const VehicleInfo & vehicle_info) const;
 
   double calc_collision_time_margin(
     const Odometry & odometry, const std::vector<polygon_utils::PointWithStamp> & collision_points,
-    const std::vector<TrajectoryPoint> & traj_points, const double dist_to_bumper) const;
+    const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper) const;
   void check_consistency(
     const rclcpp::Time & current_time,
     const std::vector<std::shared_ptr<PlannerData::Object>> & objects,
@@ -213,7 +213,7 @@ private:
   double calc_margin_from_obstacle_on_curve(
     const std::shared_ptr<const PlannerData> planner_data,
     const std::vector<TrajectoryPoint> & traj_points, const StopObstacle & stop_obstacle,
-    const double dist_to_bumper, const double default_stop_margin) const;
+    const double x_offset_to_bumper, const double default_stop_margin) const;
   std::vector<StopObstacle> get_closest_stop_obstacles(
     const std::vector<StopObstacle> & stop_obstacles);
   double get_max_lat_margin(const uint8_t obj_label) const;
@@ -228,7 +228,7 @@ private:
     const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
-    const double dist_to_bumper, const double estimation_time,
+    const double x_offset_to_bumper, const double estimation_time,
     const rclcpp::Time & predicted_objects_stamp) const;
 };
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -115,18 +116,13 @@ private:
   std::optional<std::pair<std::vector<TrajectoryPoint>, double>> prev_stop_distance_info_{
     std::nullopt};
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_{};
-  mutable std::unordered_map<double, std::vector<Polygon2d>> trajectory_polygon_for_inside_map_{};
+  mutable std::map<PolygonParam, DetectionPolygon> trajectory_polygon_for_inside_map_{};
   mutable std::optional<std::vector<Polygon2d>> decimated_traj_polys_{std::nullopt};
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{};
 
-  std::vector<geometry_msgs::msg::Point> convert_point_cloud_to_stop_points(
-    const PlannerData::Pointcloud & pointcloud, const std::vector<TrajectoryPoint> & traj_points,
-    const std::vector<Polygon2d> & decimated_traj_polys, const VehicleInfo & vehicle_info,
-    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx);
-
-  std::vector<Polygon2d> get_trajectory_polygon(
+  DetectionPolygon get_trajectory_polygon(
     const std::vector<TrajectoryPoint> & decimated_traj_points, const VehicleInfo & vehicle_info,
-    const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
+    const geometry_msgs::msg::Pose & current_ego_pose, const PolygonParam & polygon_param,
     const bool enable_to_consider_current_pose, const double time_to_convergence,
     const double decimate_trajectory_step_length) const;
 
@@ -183,6 +179,8 @@ private:
     const std::optional<double> & determined_desired_stop_margin) const;
   void publish_debug_info();
 
+  std::optional<double> calc_ego_forwarding_braking_distance(
+    const std::vector<TrajectoryPoint> & traj_points, const Odometry & odometry) const;
   std::optional<StopObstacle> pick_stop_obstacle_from_predicted_object(
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -92,14 +92,27 @@ struct ObstacleFilteringParam
   bool check_inside{};
   bool check_outside{};
 
-  struct
+  struct TrimTrajectoryParam
   {
     bool enable_trimming{};
     double min_trajectory_length{};
     double braking_distance_scale_factor{};
   } trim_trajectory;
 
-  double max_lat_margin{};
+  struct LateralMarginParam
+  {
+    double nominal_margin{};
+    double additional_wheel_off_track_scale{};
+    double is_moving_threshold_velocity{};
+    double additional_is_stop_margin{};
+    double additional_is_moving_margin{};
+
+    double max_margin(const VehicleInfo & vehicle_info) const
+    {
+      return nominal_margin + additional_wheel_off_track_scale * vehicle_info.wheel_base_m +
+             std::max(additional_is_stop_margin, additional_is_moving_margin);
+    };
+  } lateral_margin;
 
   double min_velocity_to_reach_collision_point{};
   double stop_obstacle_hold_time_threshold{};
@@ -126,7 +139,16 @@ struct ObstacleFilteringParam
     trim_trajectory.braking_distance_scale_factor = get_object_parameter<double>(
       node, param_prefix + "trim_trajectory.braking_distance_scale_factor", label_str);
 
-    max_lat_margin = get_object_parameter<double>(node, param_prefix + "max_lat_margin", label_str);
+    lateral_margin.nominal_margin =
+      get_object_parameter<double>(node, param_prefix + "lateral_margin.nominal", label_str);
+    lateral_margin.additional_wheel_off_track_scale = get_object_parameter<double>(
+      node, param_prefix + "lateral_margin.additional.wheel_off_track_scale", label_str);
+    lateral_margin.is_moving_threshold_velocity = get_object_parameter<double>(
+      node, param_prefix + "lateral_margin.additional.is_moving_threshold_velocity", label_str);
+    lateral_margin.additional_is_stop_margin = get_object_parameter<double>(
+      node, param_prefix + "lateral_margin.additional.is_stop_obstacle", label_str);
+    lateral_margin.additional_is_moving_margin = get_object_parameter<double>(
+      node, param_prefix + "lateral_margin.additional.is_moving_obstacle", label_str);
 
     min_velocity_to_reach_collision_point = get_object_parameter<double>(
       node, param_prefix + "min_velocity_to_reach_collision_point", label_str);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
@@ -147,6 +147,9 @@ protected:
     object->predicted_object.shape.dimensions.y = 2.0;
     object->predicted_object.shape.dimensions.z = 2.0;
 
+    object->predicted_object.classification.resize(1);
+    object->predicted_object.classification.at(0).label = ObjectClassification::CAR;
+
     const double time_step = 1.0;
     const double prediction_time = 30.0;
     const size_t num_points = static_cast<size_t>(prediction_time / time_step) + 1;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_parameters.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_parameters.cpp
@@ -1,0 +1,112 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "parameters.hpp"
+
+#include <autoware_utils_rclcpp/parameter.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::motion_velocity_planner
+{
+
+// Test ROS 2 node
+class TestNode : public rclcpp::Node
+{
+public:
+  TestNode() : rclcpp::Node("test_node") {}
+};
+
+// Test suite for get_object_parameter
+class GetObjectParameterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { node_ = std::make_shared<TestNode>(); }
+
+  std::shared_ptr<TestNode> node_;
+};
+
+// --- Test cases (verify priority: ns > ns.object_label > ns.default) ---
+
+// 1. Case where namespace-specific parameter is retrieved with the highest priority
+TEST_F(GetObjectParameterTest, GetNamespaceParameter_HighestPriority)
+{
+  // ns exists
+  node_->declare_parameter<int>("obstacle_stop", 100);
+  // ns.car exists
+  node_->declare_parameter<int>("obstacle_stop.car", 200);
+  // ns.default exists
+  node_->declare_parameter<int>("obstacle_stop.default", 300);
+
+  // Call the function and verify that the highest priority value (obstacle_stop) is retrieved
+  int result = get_object_parameter<int>(*node_, "obstacle_stop", "car");
+  ASSERT_EQ(result, 100);
+}
+
+// 2. Case where namespace parameter does not exist, and object-specific parameter has the next
+// priority
+TEST_F(GetObjectParameterTest, GetSpecificObjectParameter_SecondPriority)
+{
+  // ns does not exist
+  // ns.car exists
+  node_->declare_parameter<double>("obstacle_stop.car", 10.5);
+  // ns.default exists
+  node_->declare_parameter<double>("obstacle_stop.default", 20.5);
+
+  // Call the function and verify that the second highest priority value (obstacle_stop.car) is
+  // retrieved
+  double result = get_object_parameter<double>(*node_, "obstacle_stop", "car");
+  ASSERT_DOUBLE_EQ(result, 10.5);
+}
+
+// 3. Case where namespace and object parameters do not exist, and the default parameter is
+// retrieved
+TEST_F(GetObjectParameterTest, GetDefaultParameter_LowestPriority)
+{
+  // ns does not exist
+  // ns.bicycle also does not exist
+  // ns.default exists
+  node_->declare_parameter<bool>("obstacle_stop.default", true);
+
+  // Call the function and verify that the default value is retrieved
+  bool result = get_object_parameter<bool>(*node_, "obstacle_stop", "bicycle");
+  ASSERT_TRUE(result);
+}
+
+// 4. Case where an exception is thrown when no parameter is found
+TEST_F(GetObjectParameterTest, ThrowExceptionWhenNoParameterFound)
+{
+  ASSERT_THROW(
+    get_object_parameter<std::string>(*node_, "obstacle_stop", "motorcycle"), std::runtime_error);
+}
+
+// 5. Verify that parameters with a suffix also follow this priority
+TEST_F(GetObjectParameterTest, SuffixWithCustomPriority)
+{
+  // ns.value exists
+  node_->declare_parameter<double>("obstacle_stop.value", 50.0);
+  // ns.pedestrian.value exists
+  node_->declare_parameter<double>("obstacle_stop.pedestrian.value", 10.0);
+
+  // Call the function and verify that ns.value is prioritized
+  double result = get_object_parameter<double>(*node_, "obstacle_stop", "pedestrian", "value");
+  ASSERT_DOUBLE_EQ(result, 50.0);
+}
+
+}  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_types.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_types.cpp
@@ -1,0 +1,84 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "type_alias.hpp"
+#include "types.hpp"
+
+#include <gtest/gtest.h>
+
+namespace autoware::motion_velocity_planner
+{
+
+TEST(StopObstacleClassificationTest, InitializesFromPerceptionObjectClassification)
+{
+  ObjectClassification perception_obj_classification;
+
+  perception_obj_classification.label = ObjectClassification::CAR;
+  ASSERT_EQ(
+    StopObstacleClassification(perception_obj_classification).label,
+    StopObstacleClassification::Type::CAR);
+
+  perception_obj_classification.label = ObjectClassification::UNKNOWN;
+  ASSERT_EQ(
+    StopObstacleClassification(perception_obj_classification).label,
+    StopObstacleClassification::Type::UNKNOWN);
+
+  perception_obj_classification.label = ObjectClassification::PEDESTRIAN;
+  ASSERT_EQ(
+    StopObstacleClassification(perception_obj_classification).label,
+    StopObstacleClassification::Type::PEDESTRIAN);
+}
+
+TEST(StopObstacleClassificationTest, InitializesFromPredictedObjectClassification)
+{
+  PredictedObject predicted_obj;
+
+  // test by multiple classification elements
+  for (size_t i = 1; i <= 2; ++i) {
+    predicted_obj.classification.resize(i);
+
+    predicted_obj.classification.at(0).label = ObjectClassification::CAR;
+    ASSERT_EQ(
+      StopObstacleClassification(predicted_obj.classification).label,
+      StopObstacleClassification::Type::CAR);
+
+    predicted_obj.classification.at(0).label = ObjectClassification::UNKNOWN;
+    ASSERT_EQ(
+      StopObstacleClassification(predicted_obj.classification).label,
+      StopObstacleClassification::Type::UNKNOWN);
+
+    predicted_obj.classification.at(0).label = ObjectClassification::PEDESTRIAN;
+    ASSERT_EQ(
+      StopObstacleClassification(predicted_obj.classification).label,
+      StopObstacleClassification::Type::PEDESTRIAN);
+  }
+}
+
+TEST(StopObstacleClassificationTest, InitializesFromStopObstacleClassification)
+{
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::UNKNOWN}.label,
+    StopObstacleClassification::Type::UNKNOWN);
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::CAR}.label,
+    StopObstacleClassification::Type::CAR);
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::PEDESTRIAN}.label,
+    StopObstacleClassification::Type::PEDESTRIAN);
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::POINTCLOUD}.label,
+    StopObstacleClassification::Type::POINTCLOUD);
+}
+
+}  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
@@ -4,13 +4,6 @@ project(autoware_motion_velocity_planner)
 find_package(autoware_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(
-  ${PROJECT_NAME}
-  "srv/LoadPlugin.srv"
-  "srv/UnloadPlugin.srv"
-  DEPENDENCIES
-)
-
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
@@ -21,15 +14,6 @@ rclcpp_components_register_node(${PROJECT_NAME}_lib
   PLUGIN "autoware::motion_velocity_planner::MotionVelocityPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
-
-if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
-    rosidl_target_interfaces(${PROJECT_NAME}_lib
-    ${PROJECT_NAME} "rosidl_typesupport_cpp")
-else()
-    rosidl_get_typesupport_target(
-            cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-    target_link_libraries(${PROJECT_NAME}_lib "${cpp_typesupport_target}")
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
@@ -13,9 +13,6 @@
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
 
-    pointcloud:
-      mask_lat_margin: 2.0 # for compatibility with the current universe code
-
     pointcloud_preprocessing:
       filter_by_trajectory_polygon:
         enable_monolithic_crop_box: false  # [-] if true, crop pointcloud using trajectory polygon

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/config/motion_velocity_planner.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     smooth_velocity_before_planning: true  # [-] if true, smooth the velocity profile of the input trajectory before planning
 
-    trajectory_polygon_collision_check:
+    trajectory_polygon_collision_check: # used by obstacle_*_modules
       decimate_trajectory_step_length : 2.0 # longitudinal step length to calculate trajectory polygon for collision checking
       goal_extended_trajectory_length: 6.0
 
@@ -14,11 +14,23 @@
         time_to_convergence: 1.5 #[s]
 
     pointcloud:
-      pointcloud_voxel_grid_x: 0.05
-      pointcloud_voxel_grid_y: 0.05
-      pointcloud_voxel_grid_z: 100000.0
-      pointcloud_cluster_tolerance: 1.0
-      pointcloud_min_cluster_size: 1
-      pointcloud_max_cluster_size: 100000
+      mask_lat_margin: 2.0 # for compatibility with the current universe code
 
-      mask_lat_margin: 1.1
+    pointcloud_preprocessing:
+      filter_by_trajectory_polygon:
+        enable_monolithic_crop_box: false  # [-] if true, crop pointcloud using trajectory polygon
+        enable_multi_polygon_filtering: true  # [-] if true, filter pointcloud using trajectory polygon
+        min_trajectory_length: 30.0  # [m] minimum trajectory length to crop pointcloud
+        braking_distance_scale_factor: 1.5  # scale factor for brake distance to crop pointcloud
+        lateral_margin: 2.0  # lateral margin to mask pointcloud
+        height_margin: 1.0  # height margin to mask pointcloud
+      downsample_by_voxel_grid:
+        enable_downsample: true  # [-] if true, downsample
+        voxel_size_x: 0.05
+        voxel_size_y: 0.05
+        voxel_size_z: 100000.0
+      euclidean_clustering:
+        enable_clustering: true  # [-] if true, cluster pointcloud by euclidean distance, even if false, dummy indexes are prepared.
+        cluster_tolerance: 1.0 # [m] clustering tolerance
+        min_cluster_size: 1  # minimum cluster size
+        max_cluster_size: 100000  # maximum cluster size

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/schema/motion_velocity_planner.schema.json
@@ -46,42 +46,122 @@
         "pointcloud": {
           "type": "object",
           "properties": {
-            "voxel_grid_x": {
-              "type": "number",
-              "description": "voxel grid x parameter for filtering pointcloud [m]",
-              "default": "0.05"
-            },
-            "voxel_grid_y": {
-              "type": "number",
-              "description": "voxel grid y parameter for filtering pointcloud [m]",
-              "default": "0.05"
-            },
-            "voxel_grid_z": {
-              "type": "number",
-              "description": "voxel grid z parameter for filtering pointcloud [m]",
-              "default": "100000.0"
-            },
-            "pointcloud_cluster_tolerance": {
-              "type": "number",
-              "description": "pointcloud cluster tolerance parameter for clustering pointcloud [voxel]",
-              "default": "1.0"
-            },
-            "pointcloud_min_cluster_size": {
-              "type": "number",
-              "description": "pointcloud min cluster size parameter for clustering pointcloud [voxel]",
-              "default": "1"
-            },
-            "pointcloud_max_cluster_size": {
-              "type": "number",
-              "description": "pointcloud max cluster size parameter for clustering pointcloud [voxel]",
-              "default": "100000"
-            },
             "mask_lat_margin": {
               "type": "number",
-              "description": "lat margin from the input trajectory to mask-out pointcloud points [m]",
-              "default": "0.3"
+              "default": 2.0,
+              "description": "lat margin from the input trajectory to mask-out pointcloud points [m]"
             }
           }
+        },
+        "pointcloud_preprocessing": {
+          "type": "object",
+          "properties": {
+            "filter_by_trajectory_polygon": {
+              "type": "object",
+              "properties": {
+                "enable_monolithic_crop_box": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "if true, crop pointcloud using monolithic trajectory polygon"
+                },
+                "enable_multi_polygon_filtering": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "if true, filter pointcloud using multi trajectory polygons"
+                },
+                "min_trajectory_length": {
+                  "type": "number",
+                  "default": 30.0,
+                  "description": "minimum trajectory length to crop pointcloud [m]"
+                },
+                "braking_distance_scale_factor": {
+                  "type": "number",
+                  "default": 1.5,
+                  "description": "scale factor for brake distance to crop pointcloud"
+                },
+                "lateral_margin": {
+                  "type": "number",
+                  "default": 2.0,
+                  "description": "lateral margin to mask pointcloud [m]"
+                },
+                "height_margin": {
+                  "type": "number",
+                  "default": 1.0,
+                  "description": "height margin to mask pointcloud [m]"
+                }
+              },
+              "required": [
+                "enable_monolithic_crop_box",
+                "enable_multi_polygon_filtering",
+                "min_trajectory_length",
+                "braking_distance_scale_factor",
+                "lateral_margin",
+                "height_margin"
+              ]
+            },
+            "downsample_by_voxel_grid": {
+              "type": "object",
+              "properties": {
+                "enable_downsample": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "if true, downsample"
+                },
+                "voxel_size_x": {
+                  "type": "number",
+                  "default": 0.05,
+                  "description": "voxel grid x parameter for filtering pointcloud [m]"
+                },
+                "voxel_size_y": {
+                  "type": "number",
+                  "default": 0.05,
+                  "description": "voxel grid y parameter for filtering pointcloud [m]"
+                },
+                "voxel_size_z": {
+                  "type": "number",
+                  "default": 100000.0,
+                  "description": "voxel grid z parameter for filtering pointcloud [m]"
+                }
+              },
+              "required": ["enable_downsample", "voxel_size_x", "voxel_size_y", "voxel_size_z"]
+            },
+            "euclidean_clustering": {
+              "type": "object",
+              "properties": {
+                "enable_clustering": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "if true, cluster pointcloud by euclidean distance"
+                },
+                "cluster_tolerance": {
+                  "type": "number",
+                  "default": 1.0,
+                  "description": "clustering tolerance [m]"
+                },
+                "min_cluster_size": {
+                  "type": "number",
+                  "default": 1,
+                  "description": "minimum number of points per cluster"
+                },
+                "max_cluster_size": {
+                  "type": "number",
+                  "default": 100000,
+                  "description": "maximum number of points per cluster"
+                }
+              },
+              "required": [
+                "enable_clustering",
+                "cluster_tolerance",
+                "min_cluster_size",
+                "max_cluster_size"
+              ]
+            }
+          },
+          "required": [
+            "filter_by_trajectory_polygon",
+            "downsample_by_voxel_grid",
+            "euclidean_clustering"
+          ]
         }
       },
       "required": ["smooth_velocity_before_planning"],

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -178,7 +178,11 @@ bool MotionVelocityPlannerNode::update_planner_data(
     auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
     processing_times["update_planner_data.pcl.process_no_ground_pointcloud"] = sw.toc(true);
     if (no_ground_pointcloud) {
-      planner_data_->no_ground_pointcloud.set_pointcloud(std::move(*no_ground_pointcloud));
+      planner_data_->no_ground_pointcloud.preprocess_pointcloud(
+        std::move(*no_ground_pointcloud), input_traj_points, planner_data_->current_odometry,
+        planner_data_->calculate_min_deceleration_distance(0.0).value_or(0.0),
+        planner_data_->vehicle_info_, planner_data_->trajectory_polygon_collision_check,
+        planner_data_->ego_nearest_dist_threshold, planner_data_->ego_nearest_yaw_threshold);
     }
   }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -112,7 +112,7 @@ private:
   void set_velocity_smoother_params();
 
   // members
-  PlannerData planner_data_;
+  std::shared_ptr<PlannerData> planner_data_;
   MotionVelocityPlannerManager planner_manager_;
   LaneletMapBin::ConstSharedPtr map_ptr_{nullptr};
   bool has_received_map_ = false;
@@ -144,7 +144,7 @@ private:
     const autoware::motion_velocity_planner::SlowdownInterval & slowdown_interval) const;
   autoware::motion_velocity_planner::TrajectoryPoints smooth_trajectory(
     const autoware::motion_velocity_planner::TrajectoryPoints & trajectory_points,
-    const autoware::motion_velocity_planner::PlannerData & planner_data) const;
+    const std::shared_ptr<autoware::motion_velocity_planner::PlannerData> & planner_data) const;
   autoware_planning_msgs::msg::Trajectory generate_trajectory(
     const autoware::motion_velocity_planner::TrajectoryPoints & input_trajectory_points,
     std::map<std::string, double> & processing_times);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -18,8 +18,6 @@
 #include "planner_manager.hpp"
 
 #include <autoware/motion_velocity_planner_common/planner_data.hpp>
-#include <autoware_motion_velocity_planner/srv/load_plugin.hpp>
-#include <autoware_motion_velocity_planner/srv/unload_plugin.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
@@ -28,6 +26,8 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/srv/load_plugin.hpp>
+#include <autoware_internal_planning_msgs/srv/unload_plugin.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
@@ -50,9 +50,9 @@ namespace autoware::motion_velocity_planner
 {
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::srv::LoadPlugin;
+using autoware_internal_planning_msgs::srv::UnloadPlugin;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_motion_velocity_planner::srv::LoadPlugin;
-using autoware_motion_velocity_planner::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/srv/LoadPlugin.srv
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/srv/LoadPlugin.srv
@@ -1,3 +1,0 @@
-string plugin_name
----
-bool success

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/srv/UnloadPlugin.srv
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/srv/UnloadPlugin.srv
@@ -1,3 +1,0 @@
-string plugin_name
----
-bool success

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
     test/test_collision_checker.cpp
+    test/test_polygon_utils.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}
     gtest_main

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -95,6 +95,10 @@ struct PointcloudObstacleFilteringParam
 struct PlannerData
 {
 public:
+  PlannerData(const PlannerData &) = delete;
+  PlannerData & operator=(const PlannerData &) = delete;
+  PlannerData(PlannerData &&) = default;
+  PlannerData & operator=(PlannerData &&) = default;
   explicit PlannerData(rclcpp::Node & node);
   class Object
   {
@@ -146,6 +150,8 @@ public:
     void set_pointcloud(pcl::PointCloud<pcl::PointXYZ> && arg_pointcloud)
     {
       pointcloud = arg_pointcloud;
+      filtered_pointcloud_ptr.reset();
+      cluster_indices.reset();
     }
 
     pcl::PointCloud<pcl::PointXYZ> pointcloud;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -83,16 +83,6 @@ struct TrajectoryPolygonCollisionCheck
   double time_to_convergence;
 };
 
-struct PointcloudObstacleFilteringParam  // TODO(takagi): delete this obsolete parameter type
-{
-  double pointcloud_voxel_grid_x{};
-  double pointcloud_voxel_grid_y{};
-  double pointcloud_voxel_grid_z{};
-  double pointcloud_cluster_tolerance{};
-  size_t pointcloud_min_cluster_size{};
-  size_t pointcloud_max_cluster_size{};
-};
-
 struct PointcloudPreprocessParams
 {
   explicit PointcloudPreprocessParams(rclcpp::Node & node)
@@ -244,22 +234,6 @@ public:
       }
       return cluster_indices.value();
     };
-    // TODO(takagi): Remove these function after universe modules eliminates these functions.
-    const pcl::PointCloud<pcl::PointXYZ>::Ptr get_filtered_pointcloud_ptr(
-      [[maybe_unused]] const autoware::motion_velocity_planner::TrajectoryPoints &
-        trajectory_points,
-      [[maybe_unused]] const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const
-    {
-      return get_filtered_pointcloud_ptr();
-    };
-    const std::vector<pcl::PointIndices> get_cluster_indices(
-      [[maybe_unused]] const autoware::motion_velocity_planner::TrajectoryPoints &
-        trajectory_points,
-      [[maybe_unused]] const autoware::vehicle_info_utils::VehicleInfo & vehicle_info) const
-    {
-      return get_cluster_indices();
-    }
-
     PointcloudPreprocessParams preprocess_params_;
 
   private:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -77,10 +77,10 @@ struct StopPoint
 };
 struct TrajectoryPolygonCollisionCheck
 {
-  double decimate_trajectory_step_length;
-  double goal_extended_trajectory_length;
-  bool enable_to_consider_current_pose;
-  double time_to_convergence;
+  double decimate_trajectory_step_length{};
+  double goal_extended_trajectory_length{};
+  bool enable_to_consider_current_pose{};
+  double time_to_convergence{};
 };
 
 struct PointcloudPreprocessParams
@@ -170,6 +170,12 @@ public:
     }
     autoware_perception_msgs::msg::PredictedObject predicted_object;
 
+    /**
+     * @brief compute and the minimal distance to `decimated_traj_polys` by bg::distance and cache
+     * the result
+     * @note is it really OK to cache the result if the object itself is also cached and used in
+     * next iteration ?
+     */
     double get_dist_to_traj_poly(
       const std::vector<autoware_utils_geometry::Polygon2d> & decimated_traj_polys) const;
     double get_dist_to_traj_lateral(const std::vector<TrajectoryPoint> & traj_points) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -55,11 +55,26 @@ struct PointWithStamp
   geometry_msgs::msg::Point point;
 };
 
+/**
+ * @pre `traj_points` and `traj_polygons` have same size
+ * @brief find the first `traj_polygons` that collide with `obj_polygon` and amount the collision
+ * points, return the point whose distance from ego's bumper is farthest
+ */
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const geometry_msgs::msg::Point obj_position, const rclcpp::Time obj_stamp,
   const Polygon2d & obj_polygon, const double dist_to_bumper);
 
+/**
+ * @brief for each prediction step of `predicted_path`, upto
+ * `max_prediction_time_for_collision_check`, compute the representative collision point with
+ * `traj_polygons`
+ * @param collision_index contains the indices of `traj_polygons` that collide with the object for
+ * some prediction step
+ * @pre `traj_points` and `traj_polygons` have same size
+ * @post the output and `collision_index` have same size
+ * @note "bumper" denotes front line of ego if ego is driving forward, otherwise rear line of ego
+ */
 std::vector<PointWithStamp> get_collision_points(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const rclcpp::Time & obstacle_stamp, const PredictedPath & predicted_path, const Shape & shape,
@@ -67,6 +82,12 @@ std::vector<PointWithStamp> get_collision_points(
   std::vector<size_t> & collision_index, const double max_dist = std::numeric_limits<double>::max(),
   const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
 
+/**
+ * @brief return MultiPolygon whose each element represents a convex polygon comprising footprint at
+ * the corresponding index position + footprint at the previous index position
+ * @param enable_to_consider_current_pose if true, `current_ego_pose`
+ * @post the output has the same size as `traj_points`
+ */
 std::vector<Polygon2d> create_one_step_polygons(
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info,
   const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -83,8 +83,22 @@ std::vector<PointWithStamp> get_collision_points(
   const double max_prediction_time_for_collision_check = std::numeric_limits<double>::max());
 
 /**
- * @brief return MultiPolygon whose each element represents a convex polygon comprising footprint at
- * the corresponding index position + footprint at the previous index position
+ * @brief Calculate the off-tracking of the front outer wheel whichs is defined as the difference in
+ * turning radius between the front and rear outer wheels. This value is used to add a lateral
+ * margin on curves that is proportional to the front off-tracking distance. While the
+ * implementation calculates the geometrically exact value, it uses a formula designed to prevent
+ * numerical issues such as cancellation errors and division by zero. For a detailed geometric
+ * explanation, please refer to the test code:
+ * `autoware_motion_velocity_planner_common/test/test_polygon_utils.cpp`
+ * The result is approximately equal to the product of the curvature and the square of the wheelbase
+ * ($c \cdot L^2$).
+ */
+std::vector<double> calc_front_outer_wheel_off_tracking(
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
+
+/**
+ * @brief return MultiPolygon whose each element represents a convex polygon comprising footprint
+ * at the corresponding index position + footprint at the previous index position
  * @param enable_to_consider_current_pose if true, `current_ego_pose`
  * @post the output has the same size as `traj_points`
  */
@@ -92,7 +106,8 @@ std::vector<Polygon2d> create_one_step_polygons(
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info,
   const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
   const bool enable_to_consider_current_pose, const double time_to_convergence,
-  const double decimate_trajectory_step_length);
+  const double decimate_trajectory_step_length,
+  const double additional_front_outer_wheel_off_track_scale = 0.0);
 }  // namespace polygon_utils
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -46,6 +46,10 @@ using visualization_msgs::msg::MarkerArray;
 geometry_msgs::msg::Point to_geometry_point(const pcl::PointXYZ & point);
 geometry_msgs::msg::Point to_geometry_point(const autoware_utils_geometry::Point2d & point);
 
+/**
+ * @brief compute the distance between `ego_idx` and `object_pos` along `traj_points`, only when
+ * ego_idx is behind of `obstacle_pos`
+ */
 std::optional<double> calc_distance_to_front_object(
   const std::vector<TrajectoryPoint> & traj_points, const size_t ego_idx,
   const geometry_msgs::msg::Point & obstacle_pos);
@@ -59,6 +63,10 @@ std::vector<T> concat_vectors(std::vector<T> first_vector, std::vector<T> second
   return first_vector;
 }
 
+/**
+ * @brief crop part of the `traj_points` from `current_pose`, resample it by
+ * `decimate_trajectory_step_length`, and extend the end by `goal_extended_trajectory_length`
+ */
 std::vector<TrajectoryPoint> decimate_trajectory_points_from_ego(
   const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
   const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold,
@@ -80,12 +88,19 @@ std::optional<T> get_obstacle_from_uuid(
 
 std::vector<uint8_t> get_target_object_type(rclcpp::Node & node, const std::string & param_prefix);
 
+/**
+ * @brief compute the half of the diagonal length of the shape
+ */
 double calc_object_possible_max_dist_from_center(const Shape & shape);
 
 Marker get_object_marker(
   const geometry_msgs::msg::Pose & obj_pose, size_t idx, const std::string & ns, const double r,
   const double g, const double b);
 
+/**
+ * @brief compute the index of the point which overpasses `longitudinal_offset` for the 1st time,
+ * and return that index or the index next to it which is closer to `longitudinal_offset`
+ */
 template <class T>
 size_t get_index_with_longitudinal_offset(
   const T & points, const double longitudinal_offset, std::optional<size_t> start_idx)
@@ -142,14 +157,26 @@ size_t get_index_with_longitudinal_offset(
   return 0;
 }
 
+/**
+ * @brief subtract `object`'s diagonal length + `vehicle_info`'s diagonal length from the minimal
+ * distance of `object` to `traj_points`
+ * @note this sets the cache in `object`
+ */
 double calc_possible_min_dist_from_obj_to_traj_poly(
   const std::shared_ptr<PlannerData::Object> object,
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
 
+/**
+ * @brief return the minimum distance from `point` to each polygon in `decimated_traj_polys`
+ */
 double get_dist_to_traj_poly(
   const geometry_msgs::msg::Point & point,
   const std::vector<autoware_utils::Polygon2d> & decimated_traj_polys);
 
+/**
+ * @brief append the `input_points` up to `extend_length` every `step_length`, in the direction of
+ * the last point of `input_points`, keeping its vel/acc
+ */
 std::vector<TrajectoryPoint> get_extended_trajectory_points(
   const std::vector<TrajectoryPoint> & input_points, const double extend_distance,
   const double step_length);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -449,7 +449,7 @@ PlannerData::Pointcloud::filter_and_cluster_point_clouds(
       filter_by_trajectory_param.min_trajectory_length +
       min_deceleration_distance * filter_by_trajectory_param.braking_distance_scale_factor;
     const auto & trimmed_trajectory =
-      motion_utils::isDrivingForward(raw_trajectory)
+      motion_utils::isDrivingForward(raw_trajectory) == true
         ? motion_utils::cropForwardPoints(
             decimated_trajectory, decimated_trajectory.front().pose.position, 0,
             trajectory_trim_length)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -192,6 +192,7 @@ std::vector<Polygon2d> create_one_step_polygons(
 
     // estimate the future ego pose with assuming that the pose error against the reference path
     // will decrease to zero by the time_to_convergence
+    // FIXME(soblin): convergence should be applied from nearest_idx ?
     if (enable_to_consider_current_pose && time_elapsed < time_to_convergence) {
       const double rem_ratio = (time_to_convergence - time_elapsed) / time_to_convergence;
       geometry_msgs::msg::Pose indexed_pose_err;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -28,6 +28,11 @@ namespace autoware::motion_velocity_planner::polygon_utils
 {
 namespace
 {
+inline Point2d msg_to_2d(const geometry_msgs::msg::Point & point)
+{
+  return Point2d{point.x, point.y};
+}
+
 PointWithStamp calc_nearest_collision_point(
   const size_t first_within_idx, const std::vector<PointWithStamp> & collision_points,
   const std::vector<TrajectoryPoint> & decimated_traj_points, const bool is_driving_forward)
@@ -95,6 +100,79 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> get_collision_inde
 
   return std::nullopt;
 }
+
+// estimate the future ego pose with assuming that the pose error against the reference path will
+// decrease to zero by the time_to_convergence.
+// FIXME(soblin): convergence should be applied from nearest_idx ?
+std::vector<geometry_msgs::msg::Pose> calculate_error_poses(
+  const std::vector<TrajectoryPoint> & traj_points,
+  const geometry_msgs::msg::Pose & current_ego_pose, const double time_to_convergence)
+{
+  std::vector<geometry_msgs::msg::Pose> error_poses;
+  error_poses.reserve(traj_points.size());
+
+  const size_t nearest_idx =
+    autoware::motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose.position);
+  const auto nearest_pose = traj_points.at(nearest_idx).pose;
+  const auto current_ego_pose_error =
+    autoware_utils_geometry::inverse_transform_pose(current_ego_pose, nearest_pose);
+  const double current_ego_lat_error = current_ego_pose_error.position.y;
+  const double current_ego_yaw_error = tf2::getYaw(current_ego_pose_error.orientation);
+  double time_elapsed{0.0};
+
+  for (size_t i = 0; i < traj_points.size(); ++i) {
+    if (time_elapsed >= time_to_convergence) {
+      break;
+    }
+
+    const double rem_ratio = (time_to_convergence - time_elapsed) / time_to_convergence;
+    geometry_msgs::msg::Pose indexed_pose_err;
+    indexed_pose_err.set__orientation(
+      autoware_utils_geometry::create_quaternion_from_yaw(current_ego_yaw_error * rem_ratio));
+    indexed_pose_err.set__position(
+      autoware_utils_geometry::create_point(0.0, current_ego_lat_error * rem_ratio, 0.0));
+    error_poses.push_back(
+      autoware_utils_geometry::transform_pose(indexed_pose_err, traj_points.at(i).pose));
+
+    if (traj_points.at(i).longitudinal_velocity_mps != 0.0 && i < traj_points.size() - 1) {
+      time_elapsed += autoware_utils::calc_distance2d(
+                        traj_points.at(i).pose.position, traj_points.at(i + 1).pose.position) /
+                      std::abs(traj_points.at(i).longitudinal_velocity_mps);
+    } else {
+      time_elapsed = std::numeric_limits<double>::max();
+    }
+  }
+  return error_poses;
+}
+
+Polygon2d create_pose_footprint(
+  const geometry_msgs::msg::Pose & pose, const VehicleInfo & vehicle_info, const double left_margin,
+  const double right_margin)
+{
+  using autoware_utils_geometry::calc_offset_pose;
+  const double half_width = vehicle_info.vehicle_width_m / 2.0;
+  const auto point0 =
+    calc_offset_pose(pose, vehicle_info.max_longitudinal_offset_m, half_width + left_margin, 0.0)
+      .position;
+  const auto point1 =
+    calc_offset_pose(pose, vehicle_info.max_longitudinal_offset_m, -half_width - right_margin, 0.0)
+      .position;
+  const auto point2 =
+    calc_offset_pose(pose, -vehicle_info.rear_overhang_m, -half_width - right_margin, 0.0).position;
+  const auto point3 =
+    calc_offset_pose(pose, -vehicle_info.rear_overhang_m, half_width + left_margin, 0.0).position;
+
+  Polygon2d polygon;
+  boost::geometry::append(polygon, msg_to_2d(point0));
+  boost::geometry::append(polygon, msg_to_2d(point1));
+  boost::geometry::append(polygon, msg_to_2d(point2));
+  boost::geometry::append(polygon, msg_to_2d(point3));
+  boost::geometry::append(polygon, msg_to_2d(point0));
+
+  boost::geometry::correct(polygon);
+  return polygon;
+};
+
 }  // namespace
 
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
@@ -166,74 +244,89 @@ std::vector<PointWithStamp> get_collision_points(
   return collision_points;
 }
 
+// Calculate the off-tracking of the front outer wheel.
+// This is defined as the difference in turning radii between the front and rear outer wheels.
+std::vector<double> calc_front_outer_wheel_off_tracking(
+  const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info)
+{
+  auto curvature_vec = motion_utils::calcCurvature(traj_points);
+  if (motion_utils::isDrivingForward(traj_points) == false) {
+    std::transform(curvature_vec.begin(), curvature_vec.end(), curvature_vec.begin(), [](double c) {
+      return -c;
+    });
+  }
+
+  std::vector<double> front_outer_wheel_off_track(curvature_vec.size(), 0.0);
+  std::transform(
+    curvature_vec.begin(), curvature_vec.end(), front_outer_wheel_off_track.begin(),
+    [&vehicle_info](double base_link_curvature) {
+      // Calculate the curvature of the outer rear wheel's path from the curvature at the rear axle
+      // center.
+      const double base_link_outer_wheel_curvature =
+        base_link_curvature /
+        (1.0 + std::abs(base_link_curvature) * vehicle_info.vehicle_width_m / 2.0);
+      // Calculate the front outer wheel's off-tracking distance.
+      // The absolute value of this formula is equivalent to:
+      // std::hypot(radius_front_outer_wheel, wheel_base) - radius_front_outer_wheel;
+      return -1.0 * vehicle_info.wheel_base_m *
+             std::tan(0.5 * std::atan(base_link_outer_wheel_curvature * vehicle_info.wheel_base_m));
+    });
+
+  return front_outer_wheel_off_track;
+}
+
 std::vector<Polygon2d> create_one_step_polygons(
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info,
   const geometry_msgs::msg::Pose & current_ego_pose, const double lat_margin,
   const bool enable_to_consider_current_pose, const double time_to_convergence,
-  const double decimate_trajectory_step_length)
+  [[maybe_unused]] const double decimate_trajectory_step_length,
+  const double additional_front_outer_wheel_off_track_scale)
 {
+  using autoware_utils_geometry::calc_offset_pose;
   const double front_length = vehicle_info.max_longitudinal_offset_m;
   const double rear_length = vehicle_info.rear_overhang_m;
-  const double vehicle_width = vehicle_info.vehicle_width_m;
+  const double half_width = vehicle_info.vehicle_width_m / 2.0;
 
-  const size_t nearest_idx =
-    autoware::motion_utils::findNearestSegmentIndex(traj_points, current_ego_pose.position);
-  const auto nearest_pose = traj_points.at(nearest_idx).pose;
-  const auto current_ego_pose_error =
-    autoware_utils_geometry::inverse_transform_pose(current_ego_pose, nearest_pose);
-  const double current_ego_lat_error = current_ego_pose_error.position.y;
-  const double current_ego_yaw_error = tf2::getYaw(current_ego_pose_error.orientation);
-  double time_elapsed{0.0};
+  const auto error_poses =
+    enable_to_consider_current_pose
+      ? calculate_error_poses(traj_points, current_ego_pose, time_to_convergence)
+      : std::vector<geometry_msgs::msg::Pose>{};
+  const auto front_outer_wheel_off_tracks =
+    additional_front_outer_wheel_off_track_scale > 0.0
+      ? calc_front_outer_wheel_off_tracking(traj_points, vehicle_info)
+      : std::vector<double>(traj_points.size(), 0.0);
 
   std::vector<Polygon2d> output_polygons;
   Polygon2d tmp_polys{};
   for (size_t i = 0; i < traj_points.size(); ++i) {
     std::vector<geometry_msgs::msg::Pose> current_poses = {traj_points.at(i).pose};
-
-    // estimate the future ego pose with assuming that the pose error against the reference path
-    // will decrease to zero by the time_to_convergence
-    // FIXME(soblin): convergence should be applied from nearest_idx ?
-    if (enable_to_consider_current_pose && time_elapsed < time_to_convergence) {
-      const double rem_ratio = (time_to_convergence - time_elapsed) / time_to_convergence;
-      geometry_msgs::msg::Pose indexed_pose_err;
-      indexed_pose_err.set__orientation(
-        autoware_utils_geometry::create_quaternion_from_yaw(current_ego_yaw_error * rem_ratio));
-      indexed_pose_err.set__position(
-        autoware_utils_geometry::create_point(0.0, current_ego_lat_error * rem_ratio, 0.0));
-      current_poses.push_back(
-        autoware_utils_geometry::transform_pose(indexed_pose_err, traj_points.at(i).pose));
-      if (traj_points.at(i).longitudinal_velocity_mps != 0.0) {
-        time_elapsed +=
-          decimate_trajectory_step_length / std::abs(traj_points.at(i).longitudinal_velocity_mps);
-      } else {
-        time_elapsed = std::numeric_limits<double>::max();
-      }
+    if (i < error_poses.size()) {
+      current_poses.push_back(error_poses.at(i));
     }
+
+    const double left_margin = lat_margin + additional_front_outer_wheel_off_track_scale *
+                                              std::max(front_outer_wheel_off_tracks.at(i), 0.0);
+    const double right_margin = lat_margin + additional_front_outer_wheel_off_track_scale *
+                                               std::max(-front_outer_wheel_off_tracks.at(i), 0.0);
 
     Polygon2d idx_poly{};
     for (const auto & pose : current_poses) {
       if (i == 0 && traj_points.at(i).longitudinal_velocity_mps > 1e-3) {
-        boost::geometry::append(
-          idx_poly,
-          autoware_utils_geometry::to_footprint(pose, front_length, rear_length, vehicle_width)
-            .outer());
-        boost::geometry::append(
-          idx_poly, autoware_utils_geometry::from_msg(
-                      autoware_utils_geometry::calc_offset_pose(
-                        pose, front_length, vehicle_width * 0.5 + lat_margin, 0.0)
-                        .position)
-                      .to_2d());
-        boost::geometry::append(
-          idx_poly, autoware_utils_geometry::from_msg(
-                      autoware_utils_geometry::calc_offset_pose(
-                        pose, front_length, -vehicle_width * 0.5 - lat_margin, 0.0)
-                        .position)
-                      .to_2d());
+        const auto point0 =
+          calc_offset_pose(pose, front_length, half_width + left_margin, 0.0).position;
+        const auto point1 =
+          calc_offset_pose(pose, front_length, -half_width - right_margin, 0.0).position;
+        const auto point2 = calc_offset_pose(pose, -rear_length, -half_width, 0.0).position;
+        const auto point3 = calc_offset_pose(pose, -rear_length, half_width, 0.0).position;
+
+        boost::geometry::append(idx_poly, msg_to_2d(point0));
+        boost::geometry::append(idx_poly, msg_to_2d(point1));
+        boost::geometry::append(idx_poly, msg_to_2d(point2));
+        boost::geometry::append(idx_poly, msg_to_2d(point3));
+        boost::geometry::append(idx_poly, msg_to_2d(point0));
       } else {
         boost::geometry::append(
-          idx_poly, autoware_utils_geometry::to_footprint(
-                      pose, front_length, rear_length, vehicle_width + lat_margin * 2.0)
-                      .outer());
+          idx_poly, create_pose_footprint(pose, vehicle_info, left_margin, right_margin).outer());
       }
     }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -100,7 +100,7 @@ std::optional<std::pair<size_t, std::vector<PointWithStamp>>> get_collision_inde
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
   const geometry_msgs::msg::Point obj_position, const rclcpp::Time obj_stamp,
-  const Polygon2d & obj_polygon, const double dist_to_bumper)
+  const Polygon2d & obj_polygon, const double x_offset_to_bumper)
 {
   const auto collision_info =
     get_collision_index(traj_points, traj_polygons, obj_position, obj_stamp, obj_polygon);
@@ -109,7 +109,7 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   }
 
   const auto bumper_pose = autoware_utils_geometry::calc_offset_pose(
-    traj_points.at(collision_info->first).pose, dist_to_bumper, 0.0, 0.0);
+    traj_points.at(collision_info->first).pose, x_offset_to_bumper, 0.0, 0.0);
 
   std::optional<double> max_collision_length = std::nullopt;
   std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_polygon_utils.cpp
@@ -1,0 +1,153 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/polygon_utils.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+// Tests the implementation with an alternative method using elementary geometry (e.g., Pythagorean
+// theorem). This method is not used in the production code due to a division-by-zero issue on
+// straight paths.
+class OffTrackTest : public ::testing::Test
+{
+protected:
+  VehicleInfo vehicle_info_;
+  std::vector<TrajectoryPoint> trajectory_points_;
+  const double step_length_ = 2.0;
+
+  void SetUp() override
+  {
+    vehicle_info_.wheel_base_m = 2.7;
+    vehicle_info_.vehicle_width_m = 1.8;
+  }
+
+  void generate_arc_trajectory(
+    const double radius, const int rotation_sign, const bool is_driving_forward, size_t num_points)
+  {
+    trajectory_points_.clear();
+    trajectory_points_.reserve(num_points);
+
+    const double step_angle = rotation_sign * step_length_ / radius;
+    for (size_t i = 0; i < num_points; ++i) {
+      TrajectoryPoint point;
+      point.pose.position.x = radius * std::cos(i * step_angle);
+      point.pose.position.y = radius * std::sin(i * step_angle);
+      point.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(
+        is_driving_forward ? i * step_angle + rotation_sign * M_PI / 2.0
+                           : i * step_angle - rotation_sign * M_PI / 2.0);
+      trajectory_points_.push_back(point);
+    }
+  }
+  void generate_straight_trajectory(const bool is_driving_forward, size_t num_points)
+  {
+    trajectory_points_.clear();
+    trajectory_points_.reserve(num_points);
+
+    for (size_t i = 0; i < num_points; ++i) {
+      TrajectoryPoint point;
+      point.pose.position.x = i * step_length_;
+      point.pose.position.y = 0.0;
+      point.pose.orientation =
+        autoware_utils_geometry::create_quaternion_from_yaw(is_driving_forward ? 0.0 : M_PI);
+      trajectory_points_.push_back(point);
+    }
+  }
+};
+
+TEST_F(OffTrackTest, ForwardDriving)
+{
+  for (size_t num_points = 0; num_points < 10; ++num_points) {
+    generate_straight_trajectory(true, num_points);
+    const auto result =
+      autoware::motion_velocity_planner::polygon_utils::calc_front_outer_wheel_off_tracking(
+        trajectory_points_, vehicle_info_);
+    ASSERT_EQ(result.size(), num_points);
+    for (const auto & value : result) {
+      EXPECT_NEAR(value, 0.0, 1e-6);
+    }
+  }
+
+  std::vector<double> rotation_signs{1.0, -1.0};
+  std::vector<double> radius_vec{10.0, 1e3, 1e6};
+
+  const size_t num_points = 10;  // Set a fixed number of points for the arc trajectory
+  for (const auto & rotation_sign : rotation_signs) {
+    for (const auto & radius : radius_vec) {
+      generate_arc_trajectory(radius, rotation_sign, true, num_points);
+      const auto result =
+        autoware::motion_velocity_planner::polygon_utils::calc_front_outer_wheel_off_tracking(
+          trajectory_points_, vehicle_info_);
+      ASSERT_EQ(result.size(), num_points);
+
+      const auto expected_value = [&]() {
+        const double dist =
+          std::hypot(radius + vehicle_info_.vehicle_width_m / 2.0, vehicle_info_.wheel_base_m) -
+          (radius + vehicle_info_.vehicle_width_m / 2.0);
+        return -rotation_sign * dist;
+      }();
+      for (size_t i = 1; i < result.size() - 1; ++i) {
+        EXPECT_NEAR(result[i], expected_value, 1e-6);
+      }
+    }
+  }
+}
+
+TEST_F(OffTrackTest, BackwardDriving)
+{
+  for (size_t num_points = 0; num_points < 10; ++num_points) {
+    generate_straight_trajectory(false, num_points);
+    const auto result =
+      autoware::motion_velocity_planner::polygon_utils::calc_front_outer_wheel_off_tracking(
+        trajectory_points_, vehicle_info_);
+    ASSERT_EQ(result.size(), num_points);
+    for (const auto & value : result) {
+      EXPECT_NEAR(value, 0.0, 1e-6);
+    }
+  }
+
+  std::vector<double> rotation_signs{1.0, -1.0};
+  std::vector<double> radius_vec{10.0, 1e3, 1e6};
+
+  const size_t num_points = 10;  // Set a fixed number of points for the arc trajectory
+  for (const auto & rotation_sign : rotation_signs) {
+    for (const auto & radius : radius_vec) {
+      generate_arc_trajectory(radius, rotation_sign, false, num_points);
+      const auto result =
+        autoware::motion_velocity_planner::polygon_utils::calc_front_outer_wheel_off_tracking(
+          trajectory_points_, vehicle_info_);
+      ASSERT_EQ(result.size(), num_points);
+
+      const auto expected_value = [&]() {
+        const double dist =
+          std::hypot(radius + vehicle_info_.vehicle_width_m / 2.0, vehicle_info_.wheel_base_m) -
+          (radius + vehicle_info_.vehicle_width_m / 2.0);
+        return rotation_sign * dist;
+      }();
+      for (size_t i = 1; i < result.size() - 1; ++i) {
+        EXPECT_NEAR(result[i], expected_value, 1e-6);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
1. obstacle_stopの点群停止機能の更新 機能変化としては、速度推定機能の追加などです。
2. 停止物体種別ごとにパラメータを設定できるように更新
3. カーブで追加の横マージンを設ける機能を追加

ほぼ完全な後方互換性を有しています。

## Related links
https://github.com/tier4/autoware_universe/pull/2335
https://github.com/tier4/autoware_launch/pull/1100

## How was this PR tested?
1のアルゴリズム自体は実車でテスト済み
psimで物体を経路上においてエンゲージできるところまでは確認済み

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
