### PR TITLE
fix(behavior_velocity_planner): use pretty_build() to convert PathWithLaneId into Trajectory

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -17,7 +17,6 @@
 #include <autoware/trajectory/utils/find_intervals.hpp>
 #include <autoware/trajectory/utils/pretty_build.hpp>
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -14,10 +14,8 @@
 
 #include "autoware/behavior_velocity_planner/node.hpp"
 
-#include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
-#include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/utils/find_intervals.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
@@ -310,7 +308,7 @@ void BehaviorVelocityPlannerNode::onTrigger(
     return;
   }
 
-  const auto input_path = Trajectory::Builder{}.build(input_path_msg->points);
+  const auto input_path = experimental::trajectory::pretty_build(input_path_msg->points);
   if (!input_path) {
     RCLCPP_ERROR(get_logger(), "Failed to convert input path");
     return;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -14,8 +14,7 @@
 
 #include "autoware/behavior_velocity_planner/planner_manager.hpp"
 
-#include <autoware/motion_utils/trajectory/interpolation.hpp>
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
 
 #include <boost/format.hpp>
 
@@ -96,7 +95,7 @@ Trajectory BehaviorVelocityPlannerManager::planPathVelocity(
     plugin->plan(&output_path_msg);
   }
 
-  const auto output_path = Trajectory::Builder{}.build(output_path_msg.points);
+  const auto output_path = experimental::trajectory::pretty_build(output_path_msg.points);
   if (!output_path) {
     throw std::runtime_error("Failed to convert output path");
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -19,6 +19,7 @@
 #include "autoware/trajectory/utils/crossed.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -67,7 +68,7 @@ StopLineModule::StopLineModule(
 
 bool StopLineModule::modifyPathVelocity(PathWithLaneId * _path)
 {
-  auto path = Trajectory::Builder{}.build(_path->points);
+  auto path = experimental::trajectory::pretty_build(_path->points);
   if (!path) {
     logWarnThrottle(5000, "Failed to build trajectory from path points");
     return true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
@@ -16,6 +16,7 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
 #include <rclcpp/node.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -84,7 +85,7 @@ protected:
     path_.left_bound = {make_geom_point(0.0, 1.0), make_geom_point(10.0, 1.0)};
     path_.right_bound = {make_geom_point(0.0, -1.0), make_geom_point(10.0, -1.0)};
 
-    trajectory_ = *StopLineModule::Trajectory::Builder{}.build(path_.points);
+    trajectory_ = *autoware::experimental::trajectory::pretty_build(path_.points);
 
     clock_ = std::make_shared<rclcpp::Clock>();
 


### PR DESCRIPTION
## Description

Use `autoware::experimental::trajectory::pretty_build()` to convert PathWithLaneId into Trajectory.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
