### PR TITLE
feat(obstacle_stop): update feature

### DIFF
--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -85,6 +85,8 @@
         outside_obstacle: # Parameters for predicting if an obstacle will cut in. Pointcloud obstacles are not supported.
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
+          min_longitudinal_velocity: -8.0 # minimum longitudinal velocity to consider the obstacle as a stop obstacle [m/s]
+          max_moving_direction_angle: 2.44 # [rad] = 140 [deg], maximum angle of moving direction to consider the obstacle as a stop obstacle
           deceleration: # planner perceives the object will stop with this rate to avoid unnecessary stops [m/ss]
             default: 0.0
             pedestrian: 1.0

--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -9,6 +9,7 @@
         stop_margin : 5.0 # longitudinal margin to obstacle [m]
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
+        behavior_stop_margin_hold_time: 2.0 # [s] time to hold the min_behavior_stop_margin after disappearing the behavior stop point
 
         max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -85,6 +85,8 @@
         outside_obstacle: # Parameters for predicting if an obstacle will cut in. Pointcloud obstacles are not supported.
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
+          min_longitudinal_velocity: -8.0 # minimum longitudinal velocity to consider the obstacle as a stop obstacle [m/s]
+          max_moving_direction_angle: 2.44 # [rad] = 140 [deg], maximum angle of moving direction to consider the obstacle as a stop obstacle
           deceleration: # planner perceives the object will stop with this rate to avoid unnecessary stops [m/ss]
             default: 0.0
             pedestrian: 1.0

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -9,6 +9,7 @@
         stop_margin : 5.0 # longitudinal margin to obstacle [m]
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
+        behavior_stop_margin_hold_time: 2.0 # [s] time to hold the min_behavior_stop_margin after disappearing the behavior stop point
 
         max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -10,6 +10,7 @@
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
   <maintainer email="arjun.ram@tier4.jp">Arjun Ram</maintainer>
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -105,6 +105,8 @@ private:
   std::vector<StopObstacle> prev_closest_stop_obstacles_{};
   std::vector<StopObstacle> prev_stop_obstacles_{};
   std::deque<PointcloudStopCandidate> pointcloud_stop_candidates{};
+  std::optional<std::pair<rclcpp::Time, double>> last_observed_behavior_stop_time_and_margin_{
+    std::nullopt};
 
   autoware::motion_velocity_planner::obstacle_stop::PathLengthBuffer path_length_buffer_;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -117,9 +117,14 @@ struct ObstacleFilteringParam
   double min_velocity_to_reach_collision_point{};
   double stop_obstacle_hold_time_threshold{};
 
-  double outside_estimation_time_horizon{};
-  double outside_max_lateral_velocity{};
-  double outside_deceleration{};
+  struct OutsideObstacleParam
+  {
+    double estimation_time_horizon{};
+    double max_lateral_velocity{};
+    double min_longitudinal_velocity{};
+    double max_moving_direction_angle{};
+    double deceleration{};
+  } outside_obstacle;
 
   double crossing_obstacle_collision_time_margin{};
   double crossing_obstacle_traj_angle_threshold{};
@@ -155,12 +160,16 @@ struct ObstacleFilteringParam
     stop_obstacle_hold_time_threshold = get_object_parameter<double>(
       node, param_prefix + "stop_obstacle_hold_time_threshold", label_str);
 
-    outside_estimation_time_horizon = get_object_parameter<double>(
+    outside_obstacle.estimation_time_horizon = get_object_parameter<double>(
       node, param_prefix + "outside_obstacle.estimation_time_horizon", label_str);
-    outside_deceleration =
-      get_object_parameter<double>(node, param_prefix + "outside_obstacle.deceleration", label_str);
-    outside_max_lateral_velocity = get_object_parameter<double>(
+    outside_obstacle.max_lateral_velocity = get_object_parameter<double>(
       node, param_prefix + "outside_obstacle.max_lateral_velocity", label_str);
+    outside_obstacle.min_longitudinal_velocity = get_object_parameter<double>(
+      node, param_prefix + "outside_obstacle.min_longitudinal_velocity", label_str);
+    outside_obstacle.max_moving_direction_angle = get_object_parameter<double>(
+      node, param_prefix + "outside_obstacle.max_moving_direction_angle", label_str);
+    outside_obstacle.deceleration =
+      get_object_parameter<double>(node, param_prefix + "outside_obstacle.deceleration", label_str);
 
     crossing_obstacle_collision_time_margin = get_object_parameter<double>(
       node, param_prefix + "crossing_obstacle.collision_time_margin", label_str);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -245,6 +245,7 @@ struct StopPlanningParam
   double stop_margin{};
   double terminal_stop_margin{};
   double min_behavior_stop_margin{};
+  double behavior_stop_margin_hold_time{};
   double max_negative_velocity{};
   double stop_margin_opposing_traffic{};
   double effective_deceleration_opposing_traffic{};
@@ -275,6 +276,8 @@ struct StopPlanningParam
       get_or_declare_parameter<double>(node, "obstacle_stop.stop_planning.terminal_stop_margin");
     min_behavior_stop_margin = get_or_declare_parameter<double>(
       node, "obstacle_stop.stop_planning.min_behavior_stop_margin");
+    behavior_stop_margin_hold_time = get_or_declare_parameter<double>(
+      node, "obstacle_stop.stop_planning.behavior_stop_margin_hold_time");
     max_negative_velocity =
       get_or_declare_parameter<double>(node, "obstacle_stop.stop_planning.max_negative_velocity");
     stop_margin_opposing_traffic = get_or_declare_parameter<double>(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_obstacle_stop_module_outside_check.cpp
@@ -102,7 +102,6 @@ protected:
     rclcpp::init(0, nullptr);
     module_ = std::make_unique<ObstacleStopModuleWrapper>();
     // Initialize test parameters
-    obstacle_filtering_param_.outside_max_lateral_velocity = 1.0;
     stop_planning_param_.hold_stop_distance_threshold = 2.0;
 
     // Prepare test trajectory data
@@ -234,11 +233,23 @@ TEST_F(OutsideCutInObstacleTest, ValidCollisionPointWithCutInObject)
   auto pose = test_utils::create_test_pose();
   pose.position.x = 20.0;
   pose.position.y = -5.0;
-  auto object = create_test_object(1.0, 0.5, pose);
+  auto object = create_test_object(2.0, 0.5, pose);
   auto result = module_->check_outside_cut_in_obstacle_wrapper(
     object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
     dist_to_bumper_, estimation_time_, current_time_);
   EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(OutsideCutInObstacleTest, ValidCollisionPointWithOppositeCutInObject)
+{
+  auto pose = test_utils::create_test_pose();
+  pose.position.x = 20.0;
+  pose.position.y = -5.0;
+  auto object = create_test_object(-2.0, 0.5, pose);
+  auto result = module_->check_outside_cut_in_obstacle_wrapper(
+    object, traj_points_, decimated_traj_points_, decimated_traj_polys_with_lat_margin_,
+    dist_to_bumper_, estimation_time_, current_time_);
+  EXPECT_FALSE(result.has_value());
 }
 
 // TODO(takagi): move this to autoware_motion_velocity_planner_common package


### PR DESCRIPTION
## Description

1. 経路外の物体に対する停止機能に、対向車両を対象としない機能を追加しました。すでに経路内に入っている物体に対しては挙動変化はありません。
2. 交差点や横断歩道でobstacle_stopの停止線を前方にずらす機能において、ずらす判断を2秒保持するようになりました。なお、定位置をずらし続けるのみであり、停止判断の自体を2秒保持するわけではありません。

## Related links
universe: https://github.com/tier4/autoware_universe/pull/2457
launch: https://github.com/tier4/autoware_launch/pull/1172

## How was this PR tested?
psimでエンゲージできるところまで

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
