### PR TITLE
feat(planning): add processing_times topics

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -21,8 +21,10 @@
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/srv/load_plugin.hpp>
@@ -45,6 +47,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
+using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using autoware_internal_planning_msgs::srv::LoadPlugin;
 using autoware_internal_planning_msgs::srv::UnloadPlugin;
@@ -108,8 +111,10 @@ private:
   // publisher
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<Float64Stamped>::SharedPtr processing_time_publisher_;
 
   void publishDebugMarker(const autoware_planning_msgs::msg::Path & path);
+  void publishProcessingTime();
 
   //  parameter
   double forward_path_length_;
@@ -120,6 +125,7 @@ private:
   PlannerData planner_data_;
   BehaviorVelocityPlannerManager planner_manager_;
   bool is_driving_forward_{true};
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
 
   rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
   rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -77,6 +77,9 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
   // Publishers
   path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("~/output/path", 1);
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/path", 1);
+  processing_time_publisher_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/processing_time_ms", 1);
 
   // Parameters
   forward_path_length_ = declare_parameter<double>("forward_path_length");
@@ -305,6 +308,7 @@ bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 void BehaviorVelocityPlannerNode::onTrigger(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
+  stop_watch_.tic();
   std::unique_lock<std::mutex> lk(mutex_);
 
   if (!isDataReady(*get_clock())) {
@@ -334,6 +338,8 @@ void BehaviorVelocityPlannerNode::onTrigger(
   if (debug_viz_pub_->get_subscription_count() > 0) {
     publishDebugMarker(output_path_msg);
   }
+
+  publishProcessingTime();
 }
 
 autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
@@ -380,6 +386,14 @@ autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
   output_path_msg.right_bound = input_path_msg->right_bound;
 
   return output_path_msg;
+}
+
+void BehaviorVelocityPlannerNode::publishProcessingTime()
+{
+  Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch_.toc();
+  processing_time_publisher_->publish(processing_time_msg);
 }
 
 void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msgs::msg::Path & path)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -132,14 +132,6 @@ double calc_x_offset_to_bumper(const bool is_driving_forward, const VehicleInfo 
   return vehicle_info.min_longitudinal_offset_m;
 }
 
-Float64Stamped create_float64_stamped(const rclcpp::Time & now, const float & data)
-{
-  Float64Stamped msg;
-  msg.stamp = now;
-  msg.data = data;
-  return msg;
-}
-
 double calc_time_to_reach_collision_point(
   const Odometry & odometry, const geometry_msgs::msg::Point & collision_point,
   const std::vector<TrajectoryPoint> & traj_points, const double x_offset_to_bumper,
@@ -233,8 +225,6 @@ void ObstacleStopModule::init(rclcpp::Node & node, const std::string & module_na
     update_distance_th, min_off_duration, min_on_duration);
 
   // common publisher
-  processing_time_publisher_ =
-    node.create_publisher<Float64Stamped>("~/debug/obstacle_stop/processing_time_ms", 1);
   virtual_wall_publisher_ =
     node.create_publisher<visualization_msgs::msg::MarkerArray>("~/obstacle_stop/virtual_walls", 1);
   debug_publisher_ =
@@ -275,7 +265,6 @@ VelocityPlanningResult ObstacleStopModule::plan(
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
   // 1. init variables
-  stop_watch_.tic();
   debug_data_ptr_ = std::make_shared<DebugData>();
   const double x_offset_to_bumper =
     calc_x_offset_to_bumper(planner_data->is_driving_forward, planner_data->vehicle_info_);
@@ -1283,9 +1272,6 @@ void ObstacleStopModule::publish_debug_info()
 
   // 4. objects of interest
   objects_of_interest_marker_interface_->publishMarkerArray();
-
-  // 5. processing time
-  processing_time_publisher_->publish(create_float64_stamped(clock_->now(), stop_watch_.toc()));
 }
 
 DetectionPolygon ObstacleStopModule::get_trajectory_polygon(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -63,6 +63,7 @@ public:
   void publish_planning_factor() override { planning_factor_interface_->publish(); };
   void update_parameters(const std::vector<rclcpp::Parameter> & parameters) override;
   std::string get_module_name() const override { return module_name_; }
+  std::string get_short_module_name() const override { return "obstacle_stop"; }
 
   VelocityPlanningResult plan(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & raw_trajectory_points,
@@ -118,7 +119,6 @@ private:
   // crossing lanes.
   std::optional<std::pair<std::vector<TrajectoryPoint>, double>> prev_stop_distance_info_{
     std::nullopt};
-  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_{};
   mutable std::map<PolygonParam, DetectionPolygon> trajectory_polygon_for_inside_map_{};
   mutable std::optional<std::vector<Polygon2d>> decimated_traj_polys_{std::nullopt};
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{};

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -25,6 +25,7 @@
 #include <tf2/time.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -88,8 +89,7 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
   clear_velocity_limit_pub_ = this->create_publisher<VelocityLimitClearCommand>(
     "~/output/clear_velocity_limit", rclcpp::QoS{1}.transient_local());
   processing_time_publisher_ =
-    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
-      "~/debug/processing_time_ms", 1);
+    std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   debug_viz_pub_ =
     this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 1);
   debug_processed_pointcloud_pub_ =
@@ -177,8 +177,11 @@ bool MotionVelocityPlannerNode::update_planner_data(
   if (check_with_log(
         no_ground_pointcloud_ptr, "Waiting for pointcloud",
         required_subscriptions.no_ground_pointcloud)) {
+    sw.tic("process_no_ground_pointcloud");
     auto no_ground_pointcloud = process_no_ground_pointcloud(no_ground_pointcloud_ptr);
-    processing_times["update_planner_data.pcl.process_no_ground_pointcloud"] = sw.toc(true);
+    processing_times["update_planner_data.pointcloud.affine_transform"] =
+      sw.toc("process_no_ground_pointcloud");
+    sw.tic("preprocess_pointcloud");
     if (no_ground_pointcloud) {
       planner_data_->no_ground_pointcloud.preprocess_pointcloud(
         std::move(*no_ground_pointcloud), input_traj_points, planner_data_->current_odometry,
@@ -186,7 +189,10 @@ bool MotionVelocityPlannerNode::update_planner_data(
         planner_data_->vehicle_info_, planner_data_->trajectory_polygon_collision_check,
         planner_data_->ego_nearest_dist_threshold, planner_data_->ego_nearest_yaw_threshold);
     }
+    processing_times["update_planner_data.pointcloud.preprocess_for_obstacle_*_modules"] =
+      sw.toc("preprocess_pointcloud");
   }
+  processing_times["update_planner_data.pointcloud"] = sw.toc(true);
 
   const auto occupancy_grid_ptr = sub_occupancy_grid_.take_data();
   if (check_with_log(
@@ -352,10 +358,12 @@ void MotionVelocityPlannerNode::on_trajectory(
     trajectory_pub_, output_trajectory_msg.header.stamp);
   processing_times["Total"] = stop_watch.toc("Total");
   processing_diag_publisher_.publish(processing_times);
-  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
-  processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = processing_times["Total"];
-  processing_time_publisher_->publish(processing_time_msg);
+
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "processing_time_ms", processing_times["Total"]);
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "mvp_common/processing_time_ms",
+    processing_times["Total"] - processing_times["plan_velocities"]);
 }
 
 void MotionVelocityPlannerNode::insert_stop(
@@ -474,7 +482,8 @@ autoware_planning_msgs::msg::Trajectory MotionVelocityPlannerNode::generate_traj
   processing_times["calculate_time_from_start"] = stop_watch.toc("calculate_time_from_start");
   stop_watch.tic("plan_velocities");
   const auto planning_results = planner_manager_.plan_velocities(
-    input_trajectory_points, resampled_smoothed_trajectory_points, planner_data_);
+    input_trajectory_points, resampled_smoothed_trajectory_points, planner_data_,
+    processing_time_publisher_);
   processing_times["plan_velocities"] = stop_watch.toc("plan_velocities");
 
   for (const auto & planning_result : planning_results) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.hpp
@@ -18,6 +18,7 @@
 #include "planner_manager.hpp"
 
 #include <autoware/motion_velocity_planner_common/planner_data.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
@@ -102,8 +103,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr debug_processed_pointcloud_pub_;
   autoware_utils_debug::ProcessingTimePublisher processing_diag_publisher_{
     this, "~/debug/processing_time_ms_diag"};
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    processing_time_publisher_;
+  std::shared_ptr<autoware_utils_debug::DebugPublisher> processing_time_publisher_;
   autoware_utils_debug::PublishedTimePublisher published_time_publisher_{this};
 
   //  parameters

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/planner_manager.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/motion_velocity_planner_common/plugin_module_interface.hpp>
 #include <autoware/motion_velocity_planner_common/velocity_planning_result.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -46,7 +47,8 @@ public:
   std::vector<VelocityPlanningResult> plan_velocities(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & raw_trajectory_points,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
-    const std::shared_ptr<const PlannerData> planner_data);
+    const std::shared_ptr<const PlannerData> planner_data,
+    std::shared_ptr<autoware_utils_debug::DebugPublisher> & processing_time_publisher);
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const { return required_subscriptions_; }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/plugin_module_interface.hpp
@@ -48,6 +48,8 @@ public:
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
     const std::shared_ptr<const PlannerData> planner_data) = 0;
   virtual std::string get_module_name() const = 0;
+  // TODO(takagi): set const = 0 after all modules implement the override function.
+  virtual std::string get_short_module_name() const { return "module_name"; }
   virtual void publish_planning_factor() {}
   rclcpp::Logger logger_ = rclcpp::get_logger("");
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_publisher_;


### PR DESCRIPTION
## Description
processing_timeトピックの追加です。
主にはmotion_velocity_plannerへの変更です。

関連PRへの実装上の依存関係はありませんが、同時にマージが望ましいです。
https://github.com/tier4/autoware_core/pull/61
https://github.com/tier4/autoware_universe/pull/2525
https://github.com/tier4/autoware_launch/pull/1219

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
