### PR TITLE
revert(behavior_velocity_planner): support processing_time for behavior_velocity_planner (#677)"

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -21,10 +21,8 @@
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
-#include <autoware_utils_system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/srv/load_plugin.hpp>
@@ -47,7 +45,6 @@
 
 namespace autoware::behavior_velocity_planner
 {
-using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using autoware_internal_planning_msgs::srv::LoadPlugin;
 using autoware_internal_planning_msgs::srv::UnloadPlugin;
@@ -111,10 +108,8 @@ private:
   // publisher
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
-  rclcpp::Publisher<Float64Stamped>::SharedPtr processing_time_publisher_;
 
   void publishDebugMarker(const autoware_planning_msgs::msg::Path & path);
-  void publishProcessingTime();
 
   //  parameter
   double forward_path_length_;
@@ -125,7 +120,6 @@ private:
   PlannerData planner_data_;
   BehaviorVelocityPlannerManager planner_manager_;
   bool is_driving_forward_{true};
-  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
 
   rclcpp::Service<LoadPlugin>::SharedPtr srv_load_plugin_;
   rclcpp::Service<UnloadPlugin>::SharedPtr srv_unload_plugin_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -77,9 +77,6 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
   // Publishers
   path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("~/output/path", 1);
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/path", 1);
-  processing_time_publisher_ =
-    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
-      "~/debug/processing_time_ms", 1);
 
   // Parameters
   forward_path_length_ = declare_parameter<double>("forward_path_length");
@@ -308,7 +305,6 @@ bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 void BehaviorVelocityPlannerNode::onTrigger(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
-  stop_watch_.tic();
   std::unique_lock<std::mutex> lk(mutex_);
 
   if (!isDataReady(*get_clock())) {
@@ -338,8 +334,6 @@ void BehaviorVelocityPlannerNode::onTrigger(
   if (debug_viz_pub_->get_subscription_count() > 0) {
     publishDebugMarker(output_path_msg);
   }
-
-  publishProcessingTime();
 }
 
 autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
@@ -386,14 +380,6 @@ autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
   output_path_msg.right_bound = input_path_msg->right_bound;
 
   return output_path_msg;
-}
-
-void BehaviorVelocityPlannerNode::publishProcessingTime()
-{
-  Float64Stamped processing_time_msg;
-  processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = stop_watch_.toc();
-  processing_time_publisher_->publish(processing_time_msg);
 }
 
 void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msgs::msg::Path & path)


### PR DESCRIPTION
behavior_velocity_plannerが反応しなくなる問題が発生しており、疑わしい変更 https://github.com/tier4/autoware_core/pull/61 の一部をrevertします。

This reverts commit 7d6a40de647b6ce0418a95685ea7d2c5130dd131.

## Related links
https://star4.slack.com/archives/CRUE57C30/p1764922623536159?thread_ts=1764815633.503919&cid=CRUE57C30


## How was this PR tested?
ビルドして、
- エンゲージできること
- トピックが出力されていないこと
<img width="1906" height="492" alt="image" src="https://github.com/user-attachments/assets/11f2bb3d-2103-48d6-9adc-b77bb55025cd" />


## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
