### PR TITLE
feat(behavior_velocity_planner): integrate TimeKeeper for processing time tracking

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -141,6 +142,10 @@ private:
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
 
   std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
+
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
+    pub_processing_time_detail_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 
   static constexpr int logger_throttle_interval = 3000;
 };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -53,7 +54,13 @@ public:
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const { return required_subscriptions_; }
 
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper)
+  {
+    time_keeper_ = time_keeper;
+  }
+
 private:
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
   pluginlib::ClassLoader<PluginInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginInterface>> scene_manager_plugins_;
   RequiredSubscriptionInfo required_subscriptions_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -19,6 +19,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -102,6 +103,13 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
   published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
+
+  // time keeper
+  pub_processing_time_detail_ = this->create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
+    "~/debug/processing_time_detail_ms", 1);
+  time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
+
+  planner_manager_.setTimeKeeper(time_keeper_);
 }
 
 void BehaviorVelocityPlannerNode::onLoadPlugin(
@@ -133,6 +141,8 @@ void BehaviorVelocityPlannerNode::onParam()
 void BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processNoGroundPointCloud", *time_keeper_);
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(
@@ -188,6 +198,8 @@ void BehaviorVelocityPlannerNode::processOdometry(const nav_msgs::msg::Odometry:
 void BehaviorVelocityPlannerNode::processTrafficSignals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processTrafficSignals", *time_keeper_);
   // clear previous observation
   planner_data_.traffic_light_id_map_raw_.clear();
   const auto traffic_light_id_map_last_observed_old =
@@ -223,6 +235,8 @@ void BehaviorVelocityPlannerNode::processTrafficSignals(
 
 bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processData", *time_keeper_);
   bool is_ready = true;
   const auto & logData = [&clock, this](const std::string & data_type) {
     std::string msg = "Waiting for " + data_type + " data";
@@ -292,6 +306,8 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
 // NOTE: argument planner_data must not be referenced for multithreading
 bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::isDataReady", *time_keeper_);
   if (!planner_data_.velocity_smoother_) {
     RCLCPP_INFO_THROTTLE(
       get_logger(), clock, logger_throttle_interval,
@@ -305,6 +321,7 @@ bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 void BehaviorVelocityPlannerNode::onTrigger(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st("BehaviorVelocityPlannerNode::onTrigger", *time_keeper_);
   std::unique_lock<std::mutex> lk(mutex_);
 
   if (!isDataReady(*get_clock())) {
@@ -340,6 +357,8 @@ autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg,
   const PlannerData & planner_data)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::generatePath", *time_keeper_);
   autoware_planning_msgs::msg::Path output_path_msg;
 
   // TODO(someone): support backward path

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 
 #include <boost/format.hpp>
 
@@ -29,6 +30,7 @@ BehaviorVelocityPlannerManager::BehaviorVelocityPlannerManager()
 : plugin_loader_(
     "autoware_behavior_velocity_planner", "autoware::behavior_velocity_planner::PluginInterface")
 {
+  time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
 }
 
 void BehaviorVelocityPlannerManager::launchScenePlugin(
@@ -82,9 +84,14 @@ BehaviorVelocityPlannerManager::planPathVelocity(
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path_msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerManager::planPathVelocity", *time_keeper_);
   autoware_internal_planning_msgs::msg::PathWithLaneId output_path_msg = input_path_msg;
 
   for (const auto & plugin : scene_manager_plugins_) {
+    autoware_utils_debug::ScopedTimeTrack plugin_st(
+      std::string(plugin->getModuleName()), *time_keeper_);
+    plugin->setTimeKeeper(time_keeper_);
     plugin->updateSceneModuleInstances(planner_data, input_path_msg);
     plugin->plan(&output_path_msg);
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__PLUGIN_INTERFACE_HPP_
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -36,6 +37,8 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path) = 0;
   virtual const char * getModuleName() = 0;
+  virtual void setTimeKeeper(
+    const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper) = 0;
 };
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
@@ -43,6 +43,10 @@ public:
     scene_manager_->updateSceneModuleInstances(planner_data, path);
   }
   const char * getModuleName() override { return scene_manager_->getModuleName(); }
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper) override
+  {
+    scene_manager_->setTimeKeeper(time_keeper);
+  }
 
 private:
   std::unique_ptr<T> scene_manager_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -164,10 +164,7 @@ public:
 
     processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
 
-    pub_processing_time_detail_ = node.create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
-      "~/debug/processing_time_detail_ms/" + std::string(module_name), 1);
-
-    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
   }
 
   virtual ~SceneModuleManagerInterface() = default;
@@ -178,24 +175,42 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path)
   {
+    autoware_utils_debug::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::updateSceneModuleInstances (" + std::string(getModuleName()) +
+        ")",
+      *time_keeper_);
     planner_data_ = planner_data;
-
-    launchNewModules(path);
-    deleteExpiredModules(path);
+    {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::launchNewModules (" + std::string(getModuleName()) + ")",
+        *time_keeper_);
+      launchNewModules(path);
+    }
+    {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::deleteExpiredModules (" + std::string(getModuleName()) + ")",
+        *time_keeper_);
+      deleteExpiredModules(path);
+    }
   }
 
   virtual void plan(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {
+    autoware_utils_debug::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::plan (" + std::string(getModuleName()) + ")", *time_keeper_);
     modifyPathVelocity(path);
   }
 
   virtual RequiredSubscriptionInfo getRequiredSubscriptions() const = 0;
 
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper)
+  {
+    time_keeper_ = time_keeper;
+  }
+
 protected:
   virtual void modifyPathVelocity(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {
-    autoware_utils_debug::ScopedTimeTrack st(
-      "SceneModuleManagerInterface::modifyPathVelocity", *time_keeper_);
     StopWatch<std::chrono::milliseconds> stop_watch;
     stop_watch.tic("Total");
     visualization_msgs::msg::MarkerArray debug_marker_array;
@@ -293,9 +308,6 @@ protected:
     pub_debug_path_;
 
   std::shared_ptr<DebugPublisher> processing_time_publisher_;
-
-  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
-    pub_processing_time_detail_;
 
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 


### PR DESCRIPTION
## Description

Add Time Keeper to behavior_velocity_planner.
By this PR, previous time keeper topics are removed and unified timekeeper topics are published. This topic contains more information than previous one.

**sample output**

```
100.00% BehaviorVelocityPlannerNode::onTrigger: total 53.48 [ms], avg. 53.48 [ms], run count: 1
    ├── 0.22% BehaviorVelocityPlannerNode::isDataReady: total 0.12 [ms], avg. 0.12 [ms], run count: 1
    │   ├── 0.22% BehaviorVelocityPlannerNode::processData: total 0.12 [ms], avg. 0.12 [ms], run count: 1
    │   │   ├── 0.08% BehaviorVelocityPlannerNode::processNoGroundPointCloud: total 0.04 [ms], avg. 0.04 [ms], run count: 1
    │   │   └── 0.14% rest: 0.08 [ms]
    │   └── 0.00% rest: 0.00 [ms]
    ├── 98.42% BehaviorVelocityPlannerNode::generatePath: total 52.63 [ms], avg. 52.63 [ms], run count: 1
    │   ├── 97.89% BehaviorVelocityPlannerManager::planPathVelocity: total 52.35 [ms], avg. 52.35 [ms], run count: 1
    │   │   ├── 10.97% crosswalk: total 5.87 [ms], avg. 5.87 [ms], run count: 1
    │   │   │   ├── 0.87% SceneModuleManagerInterface::updateSceneModuleInstances (crosswalk): total 0.47 [ms], avg. 0.47 [ms], run count: 1
    │   │   │   │   ├── 0.51% SceneModuleManagerInterface::launchNewModules (crosswalk): total 0.27 [ms], avg. 0.27 [ms], run count: 1
    │   │   │   │   ├── 0.35% SceneModuleManagerInterface::deleteExpiredModules (crosswalk): total 0.19 [ms], avg. 0.19 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.00 [ms]
    │   │   │   ├── 10.09% SceneModuleManagerInterfaceWithRTC::plan (crosswalk): total 5.40 [ms], avg. 5.40 [ms], run count: 1
    │   │   │   │   ├── 0.01% SceneModuleManagerInterfaceWithRTC::setActivation (crosswalk): total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   │   │   ├── 10.00% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (crosswalk): total 5.35 [ms], avg. 5.35 [ms], run count: 1
    │   │   │   │   ├── 0.06% SceneModuleManagerInterfaceWithRTC::sendRTC (crosswalk): total 0.03 [ms], avg. 0.03 [ms], run count: 1
    │   │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   │   └── 0.01% rest: 0.01 [ms]
    │   │   ├── 2.05% walkway: total 1.10 [ms], avg. 1.10 [ms], run count: 1
    │   │   │   ├── 1.48% SceneModuleManagerInterface::updateSceneModuleInstances (walkway): total 0.79 [ms], avg. 0.79 [ms], run count: 1
    │   │   │   │   ├── 0.83% SceneModuleManagerInterface::launchNewModules (walkway): total 0.44 [ms], avg. 0.44 [ms], run count: 1
    │   │   │   │   ├── 0.64% SceneModuleManagerInterface::deleteExpiredModules (walkway): total 0.34 [ms], avg. 0.34 [ms], run count: 1
    │   │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   │   ├── 0.55% SceneModuleManagerInterface::plan (walkway): total 0.29 [ms], avg. 0.29 [ms], run count: 1
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   ├── 2.29% traffic_light: total 1.22 [ms], avg. 1.22 [ms], run count: 1
    │   │   │   ├── 0.20% SceneModuleManagerInterface::updateSceneModuleInstances (traffic_light): total 0.11 [ms], avg. 0.11 [ms], run count: 1
    │   │   │   │   ├── 0.12% SceneModuleManagerInterface::launchNewModules (traffic_light): total 0.06 [ms], avg. 0.06 [ms], run count: 1
    │   │   │   │   ├── 0.07% SceneModuleManagerInterface::deleteExpiredModules (traffic_light): total 0.04 [ms], avg. 0.04 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.00 [ms]
    │   │   │   ├── 2.07% SceneModuleManagerInterfaceWithRTC::plan (traffic_light): total 1.11 [ms], avg. 1.11 [ms], run count: 1
    │   │   │   │   ├── 0.01% SceneModuleManagerInterfaceWithRTC::setActivation (traffic_light): total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   │   │   ├── 1.86% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (traffic_light): total 1.00 [ms], avg. 1.00 [ms], run count: 1
    │   │   │   │   ├── 0.17% SceneModuleManagerInterfaceWithRTC::sendRTC (traffic_light): total 0.09 [ms], avg. 0.09 [ms], run count: 1
    │   │   │   │   └── 0.03% rest: 0.02 [ms]
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   ├── 39.28% intersection: total 21.00 [ms], avg. 21.00 [ms], run count: 1
    │   │   │   ├── 0.33% SceneModuleManagerInterface::updateSceneModuleInstances (intersection): total 0.18 [ms], avg. 0.18 [ms], run count: 1
    │   │   │   │   ├── 0.18% SceneModuleManagerInterface::launchNewModules (intersection): total 0.10 [ms], avg. 0.10 [ms], run count: 1
    │   │   │   │   ├── 0.14% SceneModuleManagerInterface::deleteExpiredModules (intersection): total 0.07 [ms], avg. 0.07 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.01 [ms]
    │   │   │   ├── 38.93% SceneModuleManagerInterfaceWithRTC::plan (intersection): total 20.82 [ms], avg. 20.82 [ms], run count: 1
    │   │   │   │   ├── 0.02% SceneModuleManagerInterfaceWithRTC::setActivation (intersection): total 0.01 [ms], avg. 0.01 [ms], run count: 1
    │   │   │   │   ├── 38.65% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (intersection): total 20.67 [ms], avg. 20.67 [ms], run count: 1
    │   │   │   │   ├── 0.23% SceneModuleManagerInterfaceWithRTC::sendRTC (intersection): total 0.12 [ms], avg. 0.12 [ms], run count: 1
    │   │   │   │   └── 0.03% rest: 0.01 [ms]
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   ├── 37.97% blind_spot: total 20.30 [ms], avg. 20.30 [ms], run count: 1
    │   │   │   ├── 0.21% SceneModuleManagerInterface::updateSceneModuleInstances (blind_spot): total 0.11 [ms], avg. 0.11 [ms], run count: 1
    │   │   │   │   ├── 0.12% SceneModuleManagerInterface::launchNewModules (blind_spot): total 0.07 [ms], avg. 0.07 [ms], run count: 1
    │   │   │   │   ├── 0.08% SceneModuleManagerInterface::deleteExpiredModules (blind_spot): total 0.04 [ms], avg. 0.04 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.01 [ms]
    │   │   │   ├── 37.74% SceneModuleManagerInterfaceWithRTC::plan (blind_spot): total 20.18 [ms], avg. 20.18 [ms], run count: 1
    │   │   │   │   ├── 0.01% SceneModuleManagerInterfaceWithRTC::setActivation (blind_spot): total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   │   │   ├── 37.63% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (blind_spot): total 20.12 [ms], avg. 20.12 [ms], run count: 1
    │   │   │   │   ├── 0.08% SceneModuleManagerInterfaceWithRTC::sendRTC (blind_spot): total 0.04 [ms], avg. 0.04 [ms], run count: 1
    │   │   │   │   └── 0.03% rest: 0.01 [ms]
    │   │   │   └── 0.01% rest: 0.01 [ms]
    │   │   ├── 2.06% detection_area: total 1.10 [ms], avg. 1.10 [ms], run count: 1
    │   │   │   ├── 0.27% SceneModuleManagerInterface::updateSceneModuleInstances (detection_area): total 0.15 [ms], avg. 0.15 [ms], run count: 1
    │   │   │   │   ├── 0.18% SceneModuleManagerInterface::launchNewModules (detection_area): total 0.09 [ms], avg. 0.09 [ms], run count: 1
    │   │   │   │   ├── 0.09% SceneModuleManagerInterface::deleteExpiredModules (detection_area): total 0.05 [ms], avg. 0.05 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.00 [ms]
    │   │   │   ├── 1.77% SceneModuleManagerInterfaceWithRTC::plan (detection_area): total 0.95 [ms], avg. 0.95 [ms], run count: 1
    │   │   │   │   ├── 0.01% SceneModuleManagerInterfaceWithRTC::setActivation (detection_area): total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   │   │   ├── 1.57% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (detection_area): total 0.84 [ms], avg. 0.84 [ms], run count: 1
    │   │   │   │   ├── 0.16% SceneModuleManagerInterfaceWithRTC::sendRTC (detection_area): total 0.08 [ms], avg. 0.08 [ms], run count: 1
    │   │   │   │   └── 0.04% rest: 0.02 [ms]
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   ├── 1.26% no_stopping_area: total 0.67 [ms], avg. 0.67 [ms], run count: 1
    │   │   │   ├── 0.36% SceneModuleManagerInterface::updateSceneModuleInstances (no_stopping_area): total 0.19 [ms], avg. 0.19 [ms], run count: 1
    │   │   │   │   ├── 0.23% SceneModuleManagerInterface::launchNewModules (no_stopping_area): total 0.12 [ms], avg. 0.12 [ms], run count: 1
    │   │   │   │   ├── 0.12% SceneModuleManagerInterface::deleteExpiredModules (no_stopping_area): total 0.06 [ms], avg. 0.06 [ms], run count: 1
    │   │   │   │   └── 0.01% rest: 0.01 [ms]
    │   │   │   ├── 0.88% SceneModuleManagerInterfaceWithRTC::plan (no_stopping_area): total 0.47 [ms], avg. 0.47 [ms], run count: 1
    │   │   │   │   ├── 0.00% SceneModuleManagerInterfaceWithRTC::setActivation (no_stopping_area): total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   │   │   │   ├── 0.75% SceneModuleManagerInterfaceWithRTC::modifyPathVelocity (no_stopping_area): total 0.40 [ms], avg. 0.40 [ms], run count: 1
    │   │   │   │   ├── 0.10% SceneModuleManagerInterfaceWithRTC::sendRTC (no_stopping_area): total 0.05 [ms], avg. 0.05 [ms], run count: 1
    │   │   │   │   └── 0.03% rest: 0.01 [ms]
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   ├── 1.92% stop_line: total 1.03 [ms], avg. 1.03 [ms], run count: 1
    │   │   │   ├── 0.40% SceneModuleManagerInterface::updateSceneModuleInstances (stop_line): total 0.21 [ms], avg. 0.21 [ms], run count: 1
    │   │   │   │   ├── 0.13% SceneModuleManagerInterface::launchNewModules (stop_line): total 0.07 [ms], avg. 0.07 [ms], run count: 1
    │   │   │   │   ├── 0.10% SceneModuleManagerInterface::deleteExpiredModules (stop_line): total 0.06 [ms], avg. 0.06 [ms], run count: 1
    │   │   │   │   └── 0.17% rest: 0.09 [ms]
    │   │   │   ├── 1.50% SceneModuleManagerInterface::plan (stop_line): total 0.80 [ms], avg. 0.80 [ms], run count: 1
    │   │   │   └── 0.02% rest: 0.01 [ms]
    │   │   └── 0.09% rest: 0.05 [ms]
    │   └── 0.53% rest: 0.28 [ms]
    └── 1.36% rest: 0.73 [ms]
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/processing_time_detail_ms/<module_name>` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing Time Information |
| New     | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/processing_time_detail_ms` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing Time Information |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |


### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
