### PR TITLE
feat(behavior_velocity): add time keeper

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -141,6 +142,10 @@ private:
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
 
   std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
+
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
+    pub_processing_time_detail_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 
   static constexpr int logger_throttle_interval = 3000;
 };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -53,7 +54,13 @@ public:
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const { return required_subscriptions_; }
 
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper)
+  {
+    time_keeper_ = time_keeper;
+  }
+
 private:
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
   pluginlib::ClassLoader<PluginInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginInterface>> scene_manager_plugins_;
   RequiredSubscriptionInfo required_subscriptions_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -19,6 +19,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -102,6 +103,13 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
   published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
+
+  // time keeper
+  pub_processing_time_detail_ = this->create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
+    "~/debug/processing_time_detail_ms", 1);
+  time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
+
+  planner_manager_.setTimeKeeper(time_keeper_);
 }
 
 void BehaviorVelocityPlannerNode::onLoadPlugin(
@@ -133,6 +141,8 @@ void BehaviorVelocityPlannerNode::onParam()
 void BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processNoGroundPointCloud", *time_keeper_);
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(
@@ -188,6 +198,8 @@ void BehaviorVelocityPlannerNode::processOdometry(const nav_msgs::msg::Odometry:
 void BehaviorVelocityPlannerNode::processTrafficSignals(
   const autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processTrafficSignals", *time_keeper_);
   // clear previous observation
   planner_data_.traffic_light_id_map_raw_.clear();
   const auto traffic_light_id_map_last_observed_old =
@@ -223,6 +235,8 @@ void BehaviorVelocityPlannerNode::processTrafficSignals(
 
 bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::processData", *time_keeper_);
   bool is_ready = true;
   const auto & logData = [&clock, this](const std::string & data_type) {
     std::string msg = "Waiting for " + data_type + " data";
@@ -292,6 +306,8 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
 // NOTE: argument planner_data must not be referenced for multithreading
 bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::isDataReady", *time_keeper_);
   if (!planner_data_.velocity_smoother_) {
     RCLCPP_INFO_THROTTLE(
       get_logger(), clock, logger_throttle_interval,
@@ -305,6 +321,7 @@ bool BehaviorVelocityPlannerNode::isDataReady(rclcpp::Clock clock)
 void BehaviorVelocityPlannerNode::onTrigger(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st("BehaviorVelocityPlannerNode::onTrigger", *time_keeper_);
   std::unique_lock<std::mutex> lk(mutex_);
 
   if (!isDataReady(*get_clock())) {
@@ -340,6 +357,8 @@ autoware_planning_msgs::msg::Path BehaviorVelocityPlannerNode::generatePath(
   const autoware_internal_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg,
   const PlannerData & planner_data)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerNode::generatePath", *time_keeper_);
   autoware_planning_msgs::msg::Path output_path_msg;
 
   // TODO(someone): support backward path

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 
 #include <boost/format.hpp>
 
@@ -29,6 +30,7 @@ BehaviorVelocityPlannerManager::BehaviorVelocityPlannerManager()
 : plugin_loader_(
     "autoware_behavior_velocity_planner", "autoware::behavior_velocity_planner::PluginInterface")
 {
+  time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
 }
 
 void BehaviorVelocityPlannerManager::launchScenePlugin(
@@ -82,9 +84,14 @@ BehaviorVelocityPlannerManager::planPathVelocity(
   const std::shared_ptr<const PlannerData> & planner_data,
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path_msg)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "BehaviorVelocityPlannerManager::planPathVelocity", *time_keeper_);
   autoware_internal_planning_msgs::msg::PathWithLaneId output_path_msg = input_path_msg;
 
   for (const auto & plugin : scene_manager_plugins_) {
+    autoware_utils_debug::ScopedTimeTrack plugin_st(
+      std::string(plugin->getModuleName()), *time_keeper_);
+    plugin->setTimeKeeper(time_keeper_);
     plugin->updateSceneModuleInstances(planner_data, input_path_msg);
     plugin->plan(&output_path_msg);
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__PLUGIN_INTERFACE_HPP_
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -36,6 +37,8 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path) = 0;
   virtual const char * getModuleName() = 0;
+  virtual void setTimeKeeper(
+    const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper) = 0;
 };
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
@@ -43,6 +43,10 @@ public:
     scene_manager_->updateSceneModuleInstances(planner_data, path);
   }
   const char * getModuleName() override { return scene_manager_->getModuleName(); }
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper) override
+  {
+    scene_manager_->setTimeKeeper(time_keeper);
+  }
 
 private:
   std::unique_ptr<T> scene_manager_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -164,10 +164,7 @@ public:
 
     processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
 
-    pub_processing_time_detail_ = node.create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
-      "~/debug/processing_time_detail_ms/" + std::string(module_name), 1);
-
-    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
   }
 
   virtual ~SceneModuleManagerInterface() = default;
@@ -178,24 +175,42 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path)
   {
+    autoware_utils_debug::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::updateSceneModuleInstances (" + std::string(getModuleName()) +
+        ")",
+      *time_keeper_);
     planner_data_ = planner_data;
-
-    launchNewModules(path);
-    deleteExpiredModules(path);
+    {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::launchNewModules (" + std::string(getModuleName()) + ")",
+        *time_keeper_);
+      launchNewModules(path);
+    }
+    {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::deleteExpiredModules (" + std::string(getModuleName()) + ")",
+        *time_keeper_);
+      deleteExpiredModules(path);
+    }
   }
 
   virtual void plan(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {
+    autoware_utils_debug::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::plan (" + std::string(getModuleName()) + ")", *time_keeper_);
     modifyPathVelocity(path);
   }
 
   virtual RequiredSubscriptionInfo getRequiredSubscriptions() const = 0;
 
+  void setTimeKeeper(const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper)
+  {
+    time_keeper_ = time_keeper;
+  }
+
 protected:
   virtual void modifyPathVelocity(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {
-    autoware_utils_debug::ScopedTimeTrack st(
-      "SceneModuleManagerInterface::modifyPathVelocity", *time_keeper_);
     StopWatch<std::chrono::milliseconds> stop_watch;
     stop_watch.tic("Total");
     visualization_msgs::msg::MarkerArray debug_marker_array;
@@ -293,9 +308,6 @@ protected:
     pub_debug_path_;
 
   std::shared_ptr<DebugPublisher> processing_time_publisher_;
-
-  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
-    pub_processing_time_detail_;
 
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -250,17 +250,30 @@ protected:
   virtual void deleteExpiredModules(
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path)
   {
-    const auto isModuleExpired = getModuleExpiredFunction(path);
+    auto get_module_expired_function = [this, &path]() {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::getModuleExpiredFunction (" + std::string(getModuleName()) +
+          ")",
+        *time_keeper_);
+      return getModuleExpiredFunction(path);
+    };
+    const auto isModuleExpired = get_module_expired_function();
     std::vector<int64_t> expired_module_ids;
 
-    auto itr = scene_modules_.begin();
-    while (itr != scene_modules_.end()) {
-      if (isModuleExpired(*itr)) {
-        expired_module_ids.push_back((*itr)->getModuleId());
-        registered_module_id_set_.erase((*itr)->getModuleId());
-        itr = scene_modules_.erase(itr);
-      } else {
-        itr++;
+    {
+      autoware_utils_debug::ScopedTimeTrack st(
+        "SceneModuleManagerInterface::deleteExpiredModules (while loop) (" +
+          std::string(getModuleName()) + ")",
+        *time_keeper_);
+      auto itr = scene_modules_.begin();
+      while (itr != scene_modules_.end()) {
+        if (isModuleExpired(*itr)) {
+          expired_module_ids.push_back((*itr)->getModuleId());
+          registered_module_id_set_.erase((*itr)->getModuleId());
+          itr = scene_modules_.erase(itr);
+        } else {
+          itr++;
+        }
       }
     }
 
@@ -313,7 +326,6 @@ protected:
 
   std::shared_ptr<planning_factor_interface::PlanningFactorInterface> planning_factor_interface_;
 
-private:
   void appendCommonInfo(std::ostringstream & log)
   {
     if (planner_data_ && planner_data_->current_odometry) {
@@ -361,6 +373,9 @@ private:
 
   void printDeletionInfo(const std::vector<int64_t> & expired_module_ids)
   {
+    autoware_utils_debug::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::printDeletionInfo (" + std::string(getModuleName()) + ")",
+      *time_keeper_);
     std::ostringstream log;
 
     log << "\n=== BEHAVIOR VELOCITY PLANNER MODULE DELETION ===\n"


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
