### PR TITLE
chore(autoware_lanelet_utils): cherry pick lanelet util functions

### DIFF
--- a/common/autoware_lanelet2_utils/CMakeLists.txt
+++ b/common/autoware_lanelet2_utils/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BUILD_TESTING)
     test/stop_line.cpp
     test/geometry.cpp
     test/hatched_road_marking.cpp
+    test/conversion.cpp
   )
 
   foreach (test_file IN LISTS test_files)

--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 #define AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
@@ -63,6 +65,17 @@ geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint2d & src, const double
  */
 lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Point & src);
 lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Pose & src);
+
+/**
+ * @brief serialize lanelet map message to binary ROS message
+ */
+autoware_map_msgs::msg::LaneletMapBin to_autoware_map_msgs(const lanelet::LaneletMapConstPtr & map);
+
+/**
+ * @brief deserialize lanelet map object from binary ROS message
+ */
+lanelet::LaneletMapConstPtr from_autoware_map_msgs(
+  const autoware_map_msgs::msg::LaneletMapBin & msg);
 
 }  // namespace autoware::experimental::lanelet2_utils
 #endif  // AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_

--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/conversion.hpp
@@ -15,6 +15,9 @@
 #ifndef AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 #define AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_
 
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
@@ -41,6 +44,25 @@ std::pair<lanelet::routing::RoutingGraphConstPtr, lanelet::traffic_rules::Traffi
 instantiate_routing_graph_and_traffic_rules(
   lanelet::LaneletMapConstPtr lanelet_map, const char * location = lanelet::Locations::Germany,
   const char * participant = lanelet::Participants::Vehicle);
+/**
+ * @brief convert BasicPoint3d, ConstPoint3d, BasicPoint2d, and ConstPoint2d to ROS point
+ * (geometry_msgs::msg::Point)
+ * @param src source point BasicPoint3d, ConstPoint3d, BasicPoint2d, and ConstPoint2d
+ * @param z (for 2d) z component of point
+ * @return ROS Point (geometry_msgs::msg::Point)
+ */
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint3d & src);
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint3d & src);
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint2d & src, const double & z = 0.0);
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint2d & src, const double & z = 0.0);
+
+/**
+ * @brief convert ROS Point or Pose to lanelet::ConstPoint3d
+ * @param src source point/pose
+ * @return lanelet::ConstPoint3d
+ */
+lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Point & src);
+lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Pose & src);
 
 }  // namespace autoware::experimental::lanelet2_utils
 #endif  // AUTOWARE__LANELET2_UTILS__CONVERSION_HPP_

--- a/common/autoware_lanelet2_utils/src/conversion.cpp
+++ b/common/autoware_lanelet2_utils/src/conversion.cpp
@@ -16,12 +16,18 @@
 #include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_io/Io.h>
 #include <lanelet2_io/Projection.h>
+#include <lanelet2_io/io_handlers/Serialize.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -54,6 +60,43 @@ instantiate_routing_graph_and_traffic_rules(
   auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(location, participant);
   return {
     lanelet::routing::RoutingGraph::build(*lanelet_map, *traffic_rules), std::move(traffic_rules)};
+}
+
+autoware_map_msgs::msg::LaneletMapBin to_autoware_map_msgs(const lanelet::LaneletMapConstPtr & map)
+{
+  const lanelet::LaneletMapPtr map_mut = std::const_pointer_cast<lanelet::LaneletMap>(map);
+
+  std::stringstream ss;
+  boost::archive::binary_oarchive oa(ss);
+  oa << *map_mut;
+  auto id_counter = lanelet::utils::getId();
+  oa << id_counter;
+
+  std::string data_str(ss.str());
+
+  autoware_map_msgs::msg::LaneletMapBin msg;
+  msg.data.clear();
+  msg.data.assign(data_str.begin(), data_str.end());
+  return msg;
+}
+
+lanelet::LaneletMapConstPtr from_autoware_map_msgs(
+  const autoware_map_msgs::msg::LaneletMapBin & msg)
+{
+  std::string data_str;
+  data_str.assign(msg.data.begin(), msg.data.end());
+
+  std::stringstream ss;
+  ss << data_str;
+  boost::archive::binary_iarchive oa(ss);
+
+  auto lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
+  oa >> *lanelet_map_ptr;
+  lanelet::Id id_counter = 0;
+  oa >> id_counter;
+  lanelet::utils::registerId(id_counter);
+
+  return lanelet_map_ptr;
 }
 
 geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint3d & src)

--- a/common/autoware_lanelet2_utils/src/conversion.cpp
+++ b/common/autoware_lanelet2_utils/src/conversion.cpp
@@ -56,4 +56,42 @@ instantiate_routing_graph_and_traffic_rules(
     lanelet::routing::RoutingGraph::build(*lanelet_map, *traffic_rules), std::move(traffic_rules)};
 }
 
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint3d & src)
+{
+  geometry_msgs::msg::Point dst;
+  dst.x = src.x();
+  dst.y = src.y();
+  dst.z = src.z();
+  return dst;
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint3d & src)
+{
+  return to_ros(src.basicPoint());
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::BasicPoint2d & src, const double & z)
+{
+  geometry_msgs::msg::Point dst;
+  dst.x = src.x();
+  dst.y = src.y();
+  dst.z = z;
+  return dst;
+}
+
+geometry_msgs::msg::Point to_ros(const lanelet::ConstPoint2d & src, const double & z)
+{
+  return to_ros(src.basicPoint(), z);
+}
+
+lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Point & src)
+{
+  return lanelet::ConstPoint3d(lanelet::Point3d(lanelet::InvalId, src.x, src.y, src.z));
+}
+
+lanelet::ConstPoint3d from_ros(const geometry_msgs::msg::Pose & src)
+{
+  return from_ros(src.position);
+}
+
 }  // namespace autoware::experimental::lanelet2_utils

--- a/common/autoware_lanelet2_utils/test/conversion.cpp
+++ b/common/autoware_lanelet2_utils/test/conversion.cpp
@@ -1,0 +1,110 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lanelet2_utils/conversion.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq(PointT1 & p1, PointT2 & p2)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+  ASSERT_FLOAT_EQ(p1.z, p2.z()) << "z mismatch.";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq_3d_to_2d(PointT1 & p1, PointT2 & p2, float z = 0.0)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+  ASSERT_FLOAT_EQ(p1.z, z) << "z mismatch.";
+}
+
+template <typename PointT1, typename PointT2>
+static void assert_float_point_eq_2d(PointT1 & p1, PointT2 & p2)
+{
+  ASSERT_FLOAT_EQ(p1.x, p2.x()) << "x mismatch.";
+  ASSERT_FLOAT_EQ(p1.y, p2.y()) << "y mismatch.";
+}
+
+// Test 1: to ros (BasicPoint3d->Point)
+TEST(TestConversion, BasicPoint3dToPoint)
+{
+  auto original = lanelet::BasicPoint3d(1.0, 2.0, 3.0);
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original);
+  assert_float_point_eq(ros_pt, original);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+}
+
+// Test 2: to/from ros (Point<->ConstPoint3d)
+TEST(TestConversion, RoundTripPointToConstPoint3d)
+{
+  auto original = lanelet::ConstPoint3d(lanelet::Point3d(lanelet::InvalId, 1.0, 2.0, 3.0));
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original);
+  assert_float_point_eq(ros_pt, original);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros(ros_pt);
+  assert_float_point_eq(ros_pt, converted_pt);
+  EXPECT_EQ(typeid(converted_pt), typeid(lanelet::ConstPoint3d))
+    << "converted_pt is not lanelet::ConstPoint3d.";
+}
+
+// Test 3: from ros (Pose->ConstPoint3d)
+TEST(TestConversion, PoseToConstPoint3d)
+{
+  geometry_msgs::msg::Pose original;
+  original.position.x = 1.0;
+  original.position.y = 2.0;
+  original.position.z = 3.0;
+
+  auto const_pt = autoware::experimental::lanelet2_utils::from_ros(original);
+  assert_float_point_eq(original.position, const_pt);
+  EXPECT_EQ(typeid(const_pt), typeid(lanelet::ConstPoint3d))
+    << "const_pt is not lanelet::ConstPoint3d.";
+}
+
+// Test 4: to ros (BasicPoint2d->Point)
+TEST(TestConversion, RoundTripPointToBasicPoint2d)
+{
+  auto original = lanelet::BasicPoint2d(lanelet::Point2d(lanelet::InvalId, 1.0, 2.0));
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original, 3.0);
+  assert_float_point_eq_3d_to_2d(ros_pt, original, 3.0);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+}
+
+// Test 5: to/from ros (Point<->ConstPoint2d)
+TEST(TestConversion, RoundTripPointToConstPoint2d)
+{
+  auto original = lanelet::BasicPoint2d(1.0, 2.0);
+
+  auto ros_pt = autoware::experimental::lanelet2_utils::to_ros(original, 3.0);
+  assert_float_point_eq_3d_to_2d(ros_pt, original, 3.0);
+  EXPECT_EQ(typeid(ros_pt), typeid(geometry_msgs::msg::Point))
+    << "ros_pt is not geometry_msgs::msg::Point.";
+
+  auto converted_pt = autoware::experimental::lanelet2_utils::from_ros(ros_pt);
+  auto converted_pt2d = lanelet::utils::to2D(converted_pt);
+  assert_float_point_eq_2d(ros_pt, converted_pt2d);
+  EXPECT_EQ(typeid(converted_pt2d), typeid(lanelet::ConstPoint2d))
+    << "converted_pt is not lanelet::ConstPoint2d.";
+}


### PR DESCRIPTION
## Description

This PR cherry-picks lanelet utility functions which is needed for this PR ([1](https://github.com/tier4/l4_toolkit/pull/53), [2](https://github.com/tier4/l4_toolkit/pull/54) both are private repositories).

Cherry-pick from:
https://github.com/autowarefoundation/autoware_core/pull/642
https://github.com/autowarefoundation/autoware_core/pull/648

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested that the entire meta repository that uses this branch can be built as usual.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
