### PR TITLE
feat(obstacle_stop): add height and size filter (#822)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -80,6 +80,14 @@
             is_moving_obstacle: # [m] additional stop margin for moving obstacle
               default: 0.0
 
+        detection_height: # [m] height range for collision detection from the ground.
+          top_limit:
+            default: 50.0
+            unknown: 1.0
+          bottom_limit: -50.0
+
+        min_object_length: 0.1 # [m] minimum object length to consider for stop planning
+
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -685,6 +685,31 @@ std::optional<StopObstacle> ObstacleStopModule::pick_stop_obstacle_from_predicte
     return std::nullopt;
   }
 
+  // 3. filter by height and size
+  const double obj_nearest_traj_height =
+    traj_points.at(motion_utils::findNearestIndex(traj_points, obj_pose.position)).pose.position.z;
+  if (
+    obj_pose.position.z - predicted_object.shape.dimensions.z * 0.5 - obj_nearest_traj_height >
+      filtering_params.detection_height.top_limit ||
+    obj_pose.position.z + predicted_object.shape.dimensions.z * 0.5 - obj_nearest_traj_height <
+      filtering_params.detection_height.bottom_limit) {
+    RCLCPP_DEBUG(
+      logger_,
+      "[Stop] Ignore obstacle (%s) since the height is out of range of the detection height.",
+      obj_uuid_str.substr(0, 4).c_str());
+    return std::nullopt;
+  }
+  if (
+    utils::calc_object_possible_max_dist_from_center(predicted_object.shape) * 2.0 <
+    filtering_params.min_object_length) {
+    RCLCPP_DEBUG(
+      logger_,
+      "[Stop] Ignore obstacle (%s) since the object size is smaller than the minimum object "
+      "length.",
+      obj_uuid_str.substr(0, 4).c_str());
+    return std::nullopt;
+  }
+
   // 4. check if the obstacle really collides with the trajectory
   // 4.1 generate polygon to be checked
   // calculate collision points with trajectory with lateral stop margin

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -114,6 +114,14 @@ struct ObstacleFilteringParam
     };
   } lateral_margin;
 
+  struct DetectionHeightParam
+  {
+    double top_limit{};
+    double bottom_limit{};
+  } detection_height;
+
+  double min_object_length{};
+
   double min_velocity_to_reach_collision_point{};
   double stop_obstacle_hold_time_threshold{};
 
@@ -154,6 +162,14 @@ struct ObstacleFilteringParam
       node, param_prefix + "lateral_margin.additional.is_stop_obstacle", label_str);
     lateral_margin.additional_is_moving_margin = get_object_parameter<double>(
       node, param_prefix + "lateral_margin.additional.is_moving_obstacle", label_str);
+
+    detection_height.top_limit =
+      get_object_parameter<double>(node, param_prefix + "detection_height.top_limit", label_str);
+    detection_height.bottom_limit =
+      get_object_parameter<double>(node, param_prefix + "detection_height.bottom_limit", label_str);
+
+    min_object_length =
+      get_object_parameter<double>(node, param_prefix + "min_object_length", label_str);
 
     min_velocity_to_reach_collision_point = get_object_parameter<double>(
       node, param_prefix + "min_velocity_to_reach_collision_point", label_str);


### PR DESCRIPTION
## Description
obstacle_stopの認識物体に対する検知エリアを高さ方向にも設定できるように変更します。
デフォルトのパラメータにおいては、unknownのみ地面から1mの高さまでを検知エリアとします。
unknown以外については、変更ありません。
https://star4.slack.com/archives/C09J2QMQZ1B/p1769654870848769

launch PR: https://github.com/tier4/autoware_launch.x2/pull/1873

## How was this PR tested?
psimでエンゲージできるところまでは確認しました。
細かい動作確認には、https://star4.slack.com/archives/C4P0NSMB5/p1769605715924759 も必要です。



## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
