### PR TITLE
feat: differential pcd map for RViz

### DIFF
--- a/map/autoware_core_map/launch/autoware_core_map.launch.xml
+++ b/map/autoware_core_map/launch/autoware_core_map.launch.xml
@@ -9,6 +9,8 @@
   <arg name="lanelet2_map_loader_param_path" default="$(find-pkg-share autoware_core_map)/config/lanelet2_map_loader.param.yaml"/>
   <arg name="map_projection_loader_param_path" default="$(find-pkg-share autoware_core_map)/config/map_projection_loader.param.yaml"/>
   <arg name="pointcloud_map_loader_param_path" default="$(find-pkg-share autoware_core_map)/config/pointcloud_map_loader.param.yaml"/>
+  <arg name="differential_visualizer_param_path" default="$(find-pkg-share autoware_map_loader)/config/differential_pointcloud_map_visualizer.param.yaml"/>
+  <arg name="enable_differential_pointcloud_map_visualizer" default="false" description="Publish differential pointcloud map to a topic for RViz"/>
 
   <group>
     <push-ros-namespace namespace="map"/>
@@ -36,6 +38,12 @@
     <node pkg="autoware_lanelet2_map_visualizer" exec="autoware_lanelet2_map_visualizer" name="lanelet2_map_visualization" output="both">
       <remap from="input/lanelet2_map" to="vector_map"/>
       <remap from="output/lanelet2_map_marker" to="vector_map_marker"/>
+    </node>
+
+    <node pkg="autoware_map_loader" exec="autoware_differential_pointcloud_map_visualizer" name="differential_pointcloud_map_visualizer" output="screen" if="$(var enable_differential_pointcloud_map_visualizer)">
+      <param from="$(var differential_visualizer_param_path)"/>
+      <remap from="output/differential_pointcloud_map" to="differential_pointcloud_map"/>
+      <remap from="input/pose" to="/localization/pose_estimator/pose_with_covariance"/>
     </node>
   </group>
 </launch>

--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -27,6 +27,21 @@ rclcpp_components_register_node(pointcloud_map_loader_node
   EXECUTABLE autoware_pointcloud_map_loader
 )
 
+ament_auto_add_library(differential_pointcloud_map_visualizer_node SHARED
+  src/pointcloud_map_loader/differential_pointcloud_map_visualizer_node.cpp
+)
+ament_target_dependencies(differential_pointcloud_map_visualizer_node
+  autoware_map_msgs
+  geometry_msgs
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+)
+rclcpp_components_register_node(differential_pointcloud_map_visualizer_node
+  PLUGIN "autoware::map_loader::DifferentialPointcloudMapVisualizerNode"
+  EXECUTABLE autoware_differential_pointcloud_map_visualizer
+)
+
 ament_auto_add_library(lanelet2_map_loader_node SHARED
   src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
 )

--- a/map/autoware_map_loader/README.md
+++ b/map/autoware_map_loader/README.md
@@ -102,6 +102,14 @@ Here, we assume that the pointcloud maps are divided into grids.
 Given a query and set of map IDs, the node sends a set of pointcloud maps that overlap with the queried area and are not included in the set of map IDs.
 Please see [the description of `GetDifferentialPointCloudMap.srv`](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_map_msgs#getdifferentialpointcloudmapsrv) for details.
 
+#### Visualize differential pointcloud map in RViz (ROS 2 topic)
+
+The `differential_pointcloud_map_visualizer` node calls the differential map service and publishes the result as a PointCloud2 topic so that RViz can display it. This is useful to inspect which map cells are loaded by the differential API (e.g. for debugging or when avoiding whole-map load).
+
+- **Enable**: Launch with `enable_differential_pointcloud_map_visualizer:=true` (e.g. in `autoware_core_map.launch.xml` or tier4 `map.launch.xml`).
+- **RViz**: Add a PointCloud2 display and set the topic to `/map/differential_pointcloud_map`.
+- **Parameters**: `center_x`, `center_y`, `radius` define the queried area when `use_pose` is false. Set `use_pose: true` to use the current localization pose as center (subscribe to `input/pose`, typically remapped to `/localization/pose_estimator/pose_with_covariance`). Requires divided maps and metadata for the differential service to return data.
+
 #### Send selected pointcloud map (ROS 2 service)
 
 Here, we assume that the pointcloud maps are divided into grids.

--- a/map/autoware_map_loader/config/differential_pointcloud_map_visualizer.param.yaml
+++ b/map/autoware_map_loader/config/differential_pointcloud_map_visualizer.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    # Center of the area to load [m] (used when use_pose is false)
+    center_x: 0.0
+    center_y: 0.0
+    # Radius of the cylindrical area [m]
+    radius: 200.0
+    # If true, subscribe to input/pose and use pose position as center
+    use_pose: false
+    # Update interval [s]
+    update_interval_sec: 1.0

--- a/map/autoware_map_loader/package.xml
+++ b/map/autoware_map_loader/package.xml
@@ -27,6 +27,7 @@
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>yaml-cpp</depend>
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/differential_pointcloud_map_visualizer_node.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/differential_pointcloud_map_visualizer_node.cpp
@@ -1,0 +1,118 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
+#include <autoware_map_msgs/msg/area_info.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace autoware::map_loader
+{
+
+class DifferentialPointcloudMapVisualizerNode : public rclcpp::Node
+{
+public:
+  explicit DifferentialPointcloudMapVisualizerNode(const rclcpp::NodeOptions & options)
+  : Node("differential_pointcloud_map_visualizer", options)
+  {
+    center_x_ = declare_parameter<double>("center_x", 0.0);
+    center_y_ = declare_parameter<double>("center_y", 0.0);
+    radius_ = declare_parameter<double>("radius", 200.0);
+    use_pose_ = declare_parameter<bool>("use_pose", false);
+    update_interval_sec_ = declare_parameter<double>("update_interval_sec", 1.0);
+
+    rclcpp::QoS durable_qos{1};
+    durable_qos.transient_local();
+    pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
+      "output/differential_pointcloud_map", durable_qos);
+
+    client_ = create_client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>(
+      "/map/get_differential_pointcloud_map");
+
+    if (use_pose_) {
+      sub_pose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+        "input/pose", 10, std::bind(&DifferentialPointcloudMapVisualizerNode::on_pose, this, std::placeholders::_1));
+    }
+
+    timer_ = create_wall_timer(
+      std::chrono::duration<double>(update_interval_sec_),
+      std::bind(&DifferentialPointcloudMapVisualizerNode::on_timer, this));
+  }
+
+private:
+  void on_pose(const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
+  {
+    center_x_ = msg->pose.pose.position.x;
+    center_y_ = msg->pose.pose.position.y;
+  }
+
+  void on_timer()
+  {
+    if (!client_->service_is_ready()) {
+      RCLCPP_DEBUG_THROTTLE(get_logger(), *get_clock(), 5000, "Differential map service not ready");
+      return;
+    }
+
+    auto request = std::make_shared<autoware_map_msgs::srv::GetDifferentialPointCloudMap::Request>();
+    request->area.center_x = static_cast<float>(center_x_);
+    request->area.center_y = static_cast<float>(center_y_);
+    request->area.radius = static_cast<float>(radius_);
+    request->cached_ids = {};  // Empty: get all cells in area (for visualization)
+
+    auto result = client_->async_send_request(request);
+    if (rclcpp::spin_until_future_complete(get_node_base_interface(), result, std::chrono::seconds(5)) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "Differential map service call failed");
+      return;
+    }
+
+    const auto & response = result.get();
+    sensor_msgs::msg::PointCloud2 merged;
+    for (const auto & cell : response->new_pointcloud_with_ids) {
+      if (merged.width == 0) {
+        merged = cell.pointcloud;
+      } else {
+        merged.width += cell.pointcloud.width;
+        merged.row_step += cell.pointcloud.row_step;
+        merged.data.insert(
+          merged.data.end(), cell.pointcloud.data.begin(), cell.pointcloud.data.end());
+      }
+    }
+    if (merged.width > 0) {
+      merged.header = response->header;
+      merged.header.stamp = now();
+      pub_->publish(merged);
+    }
+  }
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_;
+  rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>::SharedPtr client_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_pose_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  double center_x_;
+  double center_y_;
+  double radius_;
+  bool use_pose_;
+  double update_interval_sec_;
+};
+
+}  // namespace autoware::map_loader
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::map_loader::DifferentialPointcloudMapVisualizerNode)


### PR DESCRIPTION
## Description
WIP


---

## Title

**Add differential pointcloud map visualization for RViz**

---

## Body

```markdown
### Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've searched other issues and no duplicate issues were found.
- [ ] I've agreed with the maintainers that I can plan this task.

### Description

Currently, RViz displays the pointcloud map by subscribing to `/map/pointcloud_map`, which is published by the pointcloud map loader as a **whole** map (all PCDs loaded at once). The **differential** pointcloud map is only used internally via the `GetDifferentialPointCloudMap` service (e.g. by NDT scan matcher and compare_map_segmentation) and is not visible in RViz.

This issue proposes adding an optional node that calls the existing differential map service and publishes the result to a topic so that RViz can display the same differential-loaded map (e.g. for debugging or when using divided maps without whole-map load).

### Purpose

Allow users to visualize the differential pointcloud map in RViz, so they can verify which map cells are loaded by the differential API and debug map loading behavior without enabling whole-map load.

### Possible approaches

- Add a new node `differential_pointcloud_map_visualizer` in the `autoware_map_loader` package that:
  - Calls `/map/get_differential_pointcloud_map` (existing service) at a configurable interval or on demand.
  - Merges the returned `new_pointcloud_with_ids` into a single `sensor_msgs/PointCloud2` and publishes to a topic (e.g. `output/differential_pointcloud_map`).
- Support parameters: `center_x`, `center_y`, `radius` for the queried area; optionally follow the vehicle pose (`use_pose`) and `update_interval_sec` for periodic updates.
- Add a launch argument (e.g. `enable_differential_pointcloud_map_visualizer`) so the node is started only when needed.
- RViz continues to subscribe to a topic; users add a PointCloud2 display with the new topic (e.g. `/map/differential_pointcloud_map`) when the feature is enabled.
- Rely on the existing divided map and metadata; no changes to the differential service itself.

### Definition of done

- [ ] Implement `differential_pointcloud_map_visualizer` node that calls `GetDifferentialPointCloudMap` and publishes merged PointCloud2 (using async callback to avoid executor conflict).
- [ ] Add parameters: `center_x`, `center_y`, `radius`, `use_pose`, `update_interval_sec` and config file.
- [ ] Integrate into map launch files (e.g. `autoware_core_map.launch.xml` and tier4 `map.launch.xml`) behind an optional argument.
- [ ] Document in the map_loader README how to enable the visualizer and which RViz topic to use.
```

---

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
