### PR TITLE
feat(autoware_lanelet2_map_visualizer): add new maker (#828)

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -136,6 +136,8 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std::vector<lanelet::BusStopAreaConstPtr> bus_stop_reg_elems =
     lanelet::utils::query::busStopAreas(all_lanelets);
   lanelet::ConstLineStrings3d waypoints = lanelet::utils::query::getAllWaypoints(viz_lanelet_map);
+  lanelet::ConstPolygons3d obstacle_removal_areas =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
 
   std_msgs::msg::ColorRGBA cl_road;
   std_msgs::msg::ColorRGBA cl_shoulder;
@@ -165,6 +167,7 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std_msgs::msg::ColorRGBA cl_bus_stop_area;
   std_msgs::msg::ColorRGBA cl_bicycle_lane;
   std_msgs::msg::ColorRGBA cl_waypoints;
+  std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
   set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
   set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -193,6 +196,7 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bus_stop_area, 0.863, 0.863, 0.863, 0.5);
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
+  set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -324,6 +328,9 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   insert_marker_array(
     &map_marker_array,
     lanelet::visualization::lineStringsAsMarkerArray(waypoints, "waypoints", cl_waypoints, 0.02));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
+                         obstacle_removal_areas, cl_obstacle_removal_area));
 
   pub_marker_->publish(map_marker_array);
 }


### PR DESCRIPTION
## Description
[obstacle_removal_area_filter](https://github.com/tier4/l4_toolkit/tree/main/obstacle_removal_area_filter)の導入に伴い、可視化実装を取り込みます。

cherry-pick https://github.com/autowarefoundation/autoware_core/pull/828

## Related links

**関連slack**
アナウンススレッド ：https://star4.slack.com/archives/C03QU7K50D8/p1773028801591589
作業スレッド：https://star4.slack.com/archives/CRUE57C30/p1773032364917259

**beta/v4.3.1.2への変更PRリスト**
core: https://github.com/tier4/autoware_core/pull/82
universe: https://github.com/tier4/autoware_universe/pull/2763
launch: https://github.com/tier4/autoware_launch.x2/pull/2004
lanelet2_extension: https://github.com/tier4/autoware_lanelet2_extension/pull/1
l4_toolkit: https://github.com/tier4/l4_toolkit/pull/63




## How was this PR tested?
特定の地図でpsimを起動し、可視化が想定通りに行われることを確認しました。

## Notes for reviewers


## Interface changes



## Effects on system behavior

None.