### PR TITLE
fix(autoware_agnocast_wrapper): use rclcpp_components_register_nodes to avoid target name collision

### DIFF
--- a/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
+++ b/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
@@ -184,19 +184,15 @@ macro(autoware_agnocast_wrapper_register_node target)
         "AgnocastOnlyMultiThreadedExecutor, AgnocastOnlyCallbackIsolatedExecutor")
     endif()
 
-    # Save the values with unique prefix to avoid collision with rclcpp_components_register_node
-    set(_AGNOCAST_WRAPPER_COMPONENT ${ARGS_PLUGIN})
-    set(_AGNOCAST_WRAPPER_NODE ${ARGS_EXECUTABLE})
-
     # Register with rclcpp_components for component container support (resource index only).
     # Unlike rclcpp_components_register_node (singular), the plural form only populates
     # the ament resource index without generating an unnecessary standalone executable.
     rclcpp_components_register_nodes(${target}
-      ${_AGNOCAST_WRAPPER_COMPONENT})
+      ${ARGS_PLUGIN})
 
-    # Set template substitution variables (_AWR_ prefix) after rclcpp_components_register_node call
-    set(_AWR_node ${_AGNOCAST_WRAPPER_NODE})
-    set(_AWR_component ${_AGNOCAST_WRAPPER_COMPONENT})
+    # Set template substitution variables (_AWR_ prefix)
+    set(_AWR_node ${ARGS_EXECUTABLE})
+    set(_AWR_component ${ARGS_PLUGIN})
     set(_AWR_library_name "$<TARGET_FILE_NAME:${target}>")
 
     # Two-pass template generation:
@@ -206,19 +202,19 @@ macro(autoware_agnocast_wrapper_register_node target)
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper")
     configure_file(
       ${autoware_agnocast_wrapper_NODE_TEMPLATE}
-      ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_configured_${_AGNOCAST_WRAPPER_NODE}.cpp.in)
+      ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_configured_${ARGS_EXECUTABLE}.cpp.in)
     file(GENERATE
-      OUTPUT ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_${_AGNOCAST_WRAPPER_NODE}.cpp
-      INPUT ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_configured_${_AGNOCAST_WRAPPER_NODE}.cpp.in)
+      OUTPUT ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_${ARGS_EXECUTABLE}.cpp
+      INPUT ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_configured_${ARGS_EXECUTABLE}.cpp.in)
 
     # Create runtime-switchable executable
-    add_executable(${_AGNOCAST_WRAPPER_NODE}
-      ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_${_AGNOCAST_WRAPPER_NODE}.cpp)
+    add_executable(${ARGS_EXECUTABLE}
+      ${PROJECT_BINARY_DIR}/autoware_agnocast_wrapper/node_main_${ARGS_EXECUTABLE}.cpp)
 
-    target_link_libraries(${_AGNOCAST_WRAPPER_NODE}
+    target_link_libraries(${ARGS_EXECUTABLE}
       ${target})
 
-    ament_target_dependencies(${_AGNOCAST_WRAPPER_NODE}
+    ament_target_dependencies(${ARGS_EXECUTABLE}
       rclcpp
       rclcpp_components
       class_loader
@@ -229,10 +225,10 @@ macro(autoware_agnocast_wrapper_register_node target)
     # Both the component library and the executable must have USE_AGNOCAST_ENABLED defined
     # to ensure ABI consistency (ament_target_dependencies does not propagate PUBLIC definitions)
     autoware_agnocast_wrapper_setup(${target})
-    autoware_agnocast_wrapper_setup(${_AGNOCAST_WRAPPER_NODE})
+    autoware_agnocast_wrapper_setup(${ARGS_EXECUTABLE})
 
     # Install executable
-    install(TARGETS ${_AGNOCAST_WRAPPER_NODE}
+    install(TARGETS ${ARGS_EXECUTABLE}
       DESTINATION lib/${PROJECT_NAME})
 
   else()
@@ -252,6 +248,4 @@ macro(autoware_agnocast_wrapper_register_node target)
   unset(_AWR_node)
   unset(_AWR_component)
   unset(_AWR_library_name)
-  unset(_AGNOCAST_WRAPPER_COMPONENT)
-  unset(_AGNOCAST_WRAPPER_NODE)
 endmacro()

--- a/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
+++ b/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
@@ -68,7 +68,7 @@
 #   )
 #
 # NOTE: This is intentionally a macro (not a function) because it calls
-# rclcpp_components_register_node, which is also a macro and requires
+# rclcpp_components_register_node(s), which is also a macro and requires
 # access to the caller's variable scope for ament resource index registration.
 macro(autoware_agnocast_wrapper_register_node target)
   if(NOT TARGET ${target})

--- a/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
+++ b/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
@@ -51,10 +51,10 @@
 #   The generated template enforces this via if constexpr at compile time.
 #
 # Generated targets:
-#   When ENABLE_AGNOCAST=1 (agnocast mode), two targets are created:
+#   When ENABLE_AGNOCAST=1 (agnocast mode):
 #     - <EXECUTABLE>            : standalone executable with runtime rclcpp/agnocast switching
-#     - <EXECUTABLE>_component  : standard rclcpp_components executable for component containers
-#   When ENABLE_AGNOCAST is not set (standard mode), only one target is created:
+#     - Component registration  : rclcpp_components resource index entry for component container loading
+#   When ENABLE_AGNOCAST is not set (standard mode):
 #     - <EXECUTABLE>            : standard rclcpp_components executable (delegates to
 #                                 rclcpp_components_register_node as-is)
 #   Launch files should always reference <EXECUTABLE> for consistent behavior across both modes.
@@ -188,12 +188,11 @@ macro(autoware_agnocast_wrapper_register_node target)
     set(_AGNOCAST_WRAPPER_COMPONENT ${ARGS_PLUGIN})
     set(_AGNOCAST_WRAPPER_NODE ${ARGS_EXECUTABLE})
 
-    # Register with rclcpp_components for standard component container support
-    # Note: This call will overwrite 'node', 'component', 'library_name' variables
-    rclcpp_components_register_node(${target}
-      PLUGIN ${_AGNOCAST_WRAPPER_COMPONENT}
-      EXECUTABLE ${_AGNOCAST_WRAPPER_NODE}_component
-      EXECUTOR ${ARGS_ROS2_EXECUTOR})
+    # Register with rclcpp_components for component container support (resource index only).
+    # Unlike rclcpp_components_register_node (singular), the plural form only populates
+    # the ament resource index without generating an unnecessary standalone executable.
+    rclcpp_components_register_nodes(${target}
+      ${_AGNOCAST_WRAPPER_COMPONENT})
 
     # Set template substitution variables (_AWR_ prefix) after rclcpp_components_register_node call
     set(_AWR_node ${_AGNOCAST_WRAPPER_NODE})


### PR DESCRIPTION
## Description

Replace `rclcpp_components_register_node` (singular) with `rclcpp_components_register_nodes` (plural) in the agnocast wrapper macro.

The singular form creates both a component registration and a standalone executable named `<EXECUTABLE>_component`. This `_component` executable is never referenced from any launch file but causes CMake target name collisions when a package's library target name matches the generated executable name (e.g., `autoware_raw_vehicle_cmd_converter_node_component`).

The plural form only populates the ament resource index for component container support without generating the unnecessary executable, eliminating the collision at the root cause.

## Related links

**Parent Issue:**

- N/A

## How was this PR tested?

- [x] Built `autoware_raw_vehicle_cmd_converter` with `ENABLE_AGNOCAST=1` (clean build) — no target name collision
- [x] Verified ament resource index is correctly populated for component container loading
- [x] Confirmed no `_component` executable is generated

## Notes for reviewers

## Interface changes

None.

## Effects on system behavior

None.