### PR TITLE
fix(path_generator): prevent path truncation before current lanelet

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -228,6 +228,7 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
   auto s_ego = lanelet::utils::getArcCoordinates({current_lanelet}, current_pose).length;
   auto s_start = s_ego - params.path_length.backward;
   auto s_end = s_ego + params.path_length.forward;
+  auto current_lanelet_seen = false;
 
   const auto & goal_lanelet = route_manager_->goal_lanelet();
   auto connect_to_goal = false;
@@ -238,6 +239,7 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
       s_ego += s;
       s_start += s;
       s_end += s;
+      current_lanelet_seen = true;
     }
     if (goal_lanelet.id() == lane_id) {
       const auto s_goal = s + autoware::experimental::lanelet2_utils::get_arc_coordinates(
@@ -250,10 +252,10 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     }
 
     s += lanelet::geometry::length2d(*it);
-    if (s >= s_end + vehicle_info_.max_longitudinal_offset_m) {
+    if (current_lanelet_seen && s >= s_end + vehicle_info_.max_longitudinal_offset_m) {
       lanelets.erase(std::next(it), lanelets.end());
       break;
-    } else if (it == std::prev(lanelets.end())) {
+    } else if (current_lanelet_seen && it == std::prev(lanelets.end())) {
       s_end = std::min(s_end, s - vehicle_info_.max_longitudinal_offset_m);
     }
   }


### PR DESCRIPTION
## Description
This PR fixes an issue in `path_generator` where the path is prematurely truncated before reaching the ego vehicle's current lanelet, causing a `Failed to build trajectory from path points` error.

Since the introduction of `RouteManager` in PR #803, the lanelet sequence is provided and processed as a single continuous array (`[backward] -> [current] -> [forward]`). However, the forward path truncation logic calculates the accumulated distance `s` starting from the very beginning of this sequence. If the backward lanelets are physically long, `s` can exceed the truncation threshold (`s_end`) before the loop reaches the ego's `current_lanelet`. This triggers an early `break` and erases the ego's current and forward lanelets. 

To resolve this, a `current_lanelet_seen` guard flag was added in the sequence iteration loop. This ensures that the forward path truncation (`lanelets.erase` and `break`) only triggers after the ego vehicle's current lanelet has been explicitly passed and the `s_end` threshold is correctly updated.

## Related links
Internal: https://star4.slack.com/archives/C017VB9UG1L/p1773728712843039

## How was this PR tested?
- After the fix:
  https://evaluation.tier4.jp/evaluation/reports/d62e78b0-3b31-5c6b-8f05-b560bc5e2d32?project_id=X8ft5pPN
- Before the fix:
  https://evaluation.tier4.jp/evaluation/reports/31af6aad-f4b4-5f21-9ece-70af0a66e416?project_id=X8ft5pPN

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.

