### PR TITLE
feat(localization, sensing): cherry-pick CIE adoption PRs from upstream

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Get changed files (existing files only, excluding header-only packages)
         id: get-changed-files
         run: |
-          changed_files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
+          changed_files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
 
           # Exclude files belonging to header-only packages (no .cpp in src/).
           # These packages don't generate compile_commands.json, which causes clang-tidy to fail.

--- a/localization/autoware_ekf_localizer/CMakeLists.txt
+++ b/localization/autoware_ekf_localizer/CMakeLists.txt
@@ -24,10 +24,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/ekf_module.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::ekf_localizer::EKFLocalizer"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)

--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>eigen</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_kalman_filter</depend>
   <depend>autoware_localization_util</depend>

--- a/localization/autoware_gyro_odometer/CMakeLists.txt
+++ b/localization/autoware_gyro_odometer/CMakeLists.txt
@@ -27,10 +27,11 @@ if(BUILD_TESTING)
   )
 endif()
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::gyro_odometer::GyroOdometerNode"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/localization/autoware_gyro_odometer/package.xml
+++ b/localization/autoware_gyro_odometer/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_localization_util</depend>
   <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -51,10 +51,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 link_directories(${PCL_LIBRARY_DIRS})
 target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} multigrid_ndt_omp)
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::ndt_scan_matcher::NDTScanMatcher"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR MultiThreadedExecutor
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 if(BUILD_TESTING)

--- a/localization/autoware_ndt_scan_matcher/package.xml
+++ b/localization/autoware_ndt_scan_matcher/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_localization_util</depend>

--- a/localization/autoware_stop_filter/CMakeLists.txt
+++ b/localization/autoware_stop_filter/CMakeLists.txt
@@ -16,10 +16,11 @@ target_link_libraries(${PROJECT_NAME}_ros
   ${PROJECT_NAME}
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_ros
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_ros
   PLUGIN "autoware::stop_filter::StopFilterNode"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/localization/autoware_stop_filter/package.xml
+++ b/localization/autoware_stop_filter/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -8,10 +8,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/twist2accel.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::twist2accel::Twist2Accel"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 autoware_ament_auto_package(

--- a/localization/autoware_twist2accel/package.xml
+++ b/localization/autoware_twist2accel/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_signal_processing</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
+++ b/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
@@ -8,10 +8,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/vehicle_velocity_converter.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::vehicle_velocity_converter::VehicleVelocityConverter"
   EXECUTABLE ${PROJECT_NAME}_node
-  EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/sensing/autoware_vehicle_velocity_converter/package.xml
+++ b/sensing/autoware_vehicle_velocity_converter/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
## Description

Cherry-pick the following upstream PRs to adopt CIE (Callback Isolated Executor) via `autoware_agnocast_wrapper` for localization and sensing packages:

- autowarefoundation/autoware_core#966 feat(autoware_ndt_scan_matcher): apply autoware_agnocast_wrapper for CIE
- autowarefoundation/autoware_core#961 feat(autoware_gyro_odometer): adopt cie
- autowarefoundation/autoware_core#962 feat(autoware_ekf_localizer): adopt cie
- autowarefoundation/autoware_core#963 feat(autoware_stop_filter): adopt cie
- autowarefoundation/autoware_core#964 feat(autoware_twist2accel): adopt cie
- autowarefoundation/autoware_core#965 feat(autoware_vehicle_velocity_converter): adopt cie
- autowarefoundation/autoware_core#946 fix(ci): handle PRs with no C++ file changes in clang-tidy step

## Tests performed

Each PR has been reviewed and tested before being merged into tier4/main.

## Effects on system behavior

When ENABLE_AGNOCAST=0 (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When ENABLE_AGNOCAST=1, the executor switches to CallbackIsolatedAgnocastExecutor (CIE). Internally, CIE creates a dedicated rclcpp::executors::SingleThreadedExecutor for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using rclcpp::executors::SingleThreadedExecutor, callback groups now run in parallel across separate threads, similar to MultiThreadedExecutor.

## Interface changes

No interface changes.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/