### PR TITLE
feat(autoware_agnocast_wrapper): use glog

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -55,6 +55,11 @@ ament_export_dependencies(
   glog
 )
 
+ament_export_libraries(
+  ${PROJECT_NAME}
+  glog
+)
+
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   ament_export_dependencies(
     agnocastlib

--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -30,7 +30,7 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     agnocastlib
     autoware_utils_rclcpp
     message_filters
-    glog::glog
+    glog
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -38,7 +38,7 @@ else()
     rclcpp
     autoware_utils_rclcpp
     message_filters
-    glog::glog
+    glog
   )
 endif()
 

--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -7,6 +7,7 @@ autoware_package()
 find_package(rclcpp REQUIRED)
 find_package(autoware_utils_rclcpp REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(glog REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(agnocastlib REQUIRED)
@@ -29,6 +30,7 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     agnocastlib
     autoware_utils_rclcpp
     message_filters
+    glog::glog
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -36,6 +38,7 @@ else()
     rclcpp
     autoware_utils_rclcpp
     message_filters
+    glog::glog
   )
 endif()
 
@@ -49,6 +52,7 @@ ament_export_dependencies(
   message_filters
   rclcpp
   rclcpp_components
+  glog
 )
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,6 +15,7 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
+  <build>libgoogle-glog-dev</build>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,7 +15,7 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
-  <build>libgoogle-glog-dev</build>
+  <depend>libgoogle-glog-dev</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
+++ b/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <glog/logging.h>
 
 #include "agnocast/agnocast.hpp"
 #include "@_AWR_agnocast_executor_include@"
@@ -31,6 +32,9 @@
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   constexpr bool agnocast_only = @_AWR_agnocast_only@;
   const bool use_agnocast = autoware::agnocast_wrapper::use_agnocast();
   const bool is_agnocast_only_mode = use_agnocast && agnocast_only;


### PR DESCRIPTION
## Description
Apply glog to nodes that depend on agnocast_wrapper.
There is a requirement from the Tier IV product side to utilize stack traces when a process crashes. In tier4/rclcpp, glog is applied via files such as node_main.cpp.in, which allows rclcpp::Node and component_container to capture stack traces. However, when generating binaries using autowre_agnocast_wrapper_register_node, the template functions in gnode_switcheable.cpp.in are used, making it impossible to obtain stack traces in the current state. This change applies glog in the same manner as tier4/rclcpp.

## Related links

**Parent Issue:**

- [TIER IV internal link](https://star4.slack.com/archives/C07K1PPNPTR/p1773724442560229?thread_ts=1773698404.361139&cid=C07K1PPNPTR)

## How was this PR tested?
None.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
