### PR TITLE
ci: import stable branch workflow

### DIFF
--- a/.github/workflows/update-stable-branch.yaml
+++ b/.github/workflows/update-stable-branch.yaml
@@ -1,0 +1,68 @@
+name: Update Stable Branch
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
+
+jobs:
+  update-stable:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Determine target tag
+        id: determine-tag
+        run: |
+          # Get all tags matching vX.Y.Z pattern and sort them
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)
+          echo "Latest tag: $LATEST_TAG"
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "Error: No matching tags found."
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Workflow manually triggered. Targeting latest tag: $LATEST_TAG"
+            TARGET_TAG="$LATEST_TAG"
+          else
+            CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+            echo "Current tag: $CURRENT_TAG"
+
+            if [ "$CURRENT_TAG" != "$LATEST_TAG" ]; then
+              echo "Error: $CURRENT_TAG is not the latest vX.Y.Z tag. Latest is $LATEST_TAG"
+              exit 1
+            fi
+
+            echo "$CURRENT_TAG is the latest vX.Y.Z tag. Updating stable branch."
+            TARGET_TAG="$CURRENT_TAG"
+          fi
+
+          echo "target_tag=$TARGET_TAG" >> $GITHUB_OUTPUT
+
+      - name: Update stable branch
+        run: |
+          TARGET_TAG="${{ steps.determine-tag.outputs.target_tag }}"
+          git checkout "$TARGET_TAG"
+          git checkout -B stable
+          git push origin stable --force-with-lease


### PR DESCRIPTION
## Description

Add stable branch workflow analogous to https://github.com/tier4/autoware_launch/pull/1279 , which points to the latest vX.Y.Z.

(unlike autoware_launch side, follow-up PR like https://github.com/tier4/autoware_launch/pull/1295 is not necessary, since we are NOT merging)

This default branch is CI-only branch, so analogous to https://github.com/tier4/autoware_universe/pull/2812 , it would not interfere with awf-latest.

## How was this PR tested?

In tier4/autoware_launch repository.

## Notes for reviewers

`stable` branch should be branch protected analogous to https://github.com/tier4/autoware_launch/pull/1279 , after the merge.

## Effects on system behavior

None.
