### PR TITLE
feat(cherry-pick): add adjustable publishing ekf_localizaer diagnostics

### DIFF
--- a/localization/autoware_ekf_localizer/config/ekf_localizer.param.yaml
+++ b/localization/autoware_ekf_localizer/config/ekf_localizer.param.yaml
@@ -43,6 +43,8 @@
       warn_ellipse_size: 1.2
       error_ellipse_size_lateral_direction: 0.3
       warn_ellipse_size_lateral_direction: 0.25
+      # diagnostics publish frequency [Hz] (must be > 0)
+      diagnostics_publish_frequency: 10.0
 
     misc:
       # for velocity measurement limitation (Set 0.0 if you want to ignore)

--- a/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/ekf_localizer.hpp
@@ -22,13 +22,14 @@
 
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2/utils.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
-#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -43,9 +44,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <chrono>
-#include <iostream>
 #include <memory>
-#include <queue>
 #include <string>
 #include <vector>
 
@@ -82,8 +81,6 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_biased_pose_;
   //!< @brief ekf estimated yaw bias publisher
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_biased_pose_cov_;
-  //!< @brief diagnostics publisher
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diag_;
   //!< @brief processing_time publisher
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
@@ -127,6 +124,18 @@ private:
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
 
+  //!< @brief diagnostic updater for publishing diagnostics at configured period
+  diagnostic_updater::Updater diagnostics_;
+  //!< @brief Merged diagnostic status from the latest EKF cycle (message/values refresh every tick)
+  diagnostic_msgs::msg::DiagnosticStatus merged_diagnostic_status_;
+  //!< @brief Wall time of the latest merged diagnostic level change vs. the previous EKF tick
+  //!< (includes recovery to OK); published as last_level_transition_timestamp once non-zero
+  rclcpp::Time merged_diagnostic_last_transition_time_;
+  //!< @brief last pose callback header stamp (for callback_pose diagnostic)
+  rclcpp::Time last_pose_callback_time_;
+  //!< @brief last twist callback header stamp (for callback_twist diagnostic)
+  rclcpp::Time last_twist_callback_time_;
+
   /**
    * @brief computes update & prediction of EKF for each ekf_dt_[s] time
    */
@@ -169,16 +178,29 @@ private:
     const geometry_msgs::msg::TwistStamped & current_ekf_twist);
 
   /**
-   * @brief publish diagnostics message
+   * @brief Overwrite merged_diagnostic_status_ from merged diagnostics each tick;
+   * force_update() when merged severity increases vs. the previous EKF tick
+   * (last transition time updates on any level change).
    */
-  void publish_diagnostics(
-    const geometry_msgs::msg::PoseStamped & current_ekf_pose, const rclcpp::Time & current_time);
+  void update_diagnostics(
+    const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & diag_status_array,
+    const rclcpp::Time & current_time);
 
   /**
-   * @brief publish diagnostics message for return
+   * @brief diagnostic function called by diagnostic_updater::Updater
+   * @param stat diagnostic status wrapper to fill
    */
-  void publish_callback_return_diagnostics(
-    const std::string & callback_name, const rclcpp::Time & current_time);
+  void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  /**
+   * @brief diagnostic for callback_pose (diagnostic_updater task)
+   */
+  void diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  /**
+   * @brief diagnostic for callback_twist (diagnostic_updater task)
+   */
+  void diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   /**
    * @brief trigger node
@@ -190,7 +212,7 @@ private:
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_;
   autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch_timer_cb_;
 
-  friend class EKFLocalizerTestSuite;  // for test code
+  friend class EKFLocalizerDiagnosticsTest;  // for test code
 };
 
 }  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/hyper_parameters.hpp
+++ b/localization/autoware_ekf_localizer/include/autoware/ekf_localizer/hyper_parameters.hpp
@@ -66,14 +66,17 @@ public:
       node->declare_parameter<double>("diagnostics.error_ellipse_size_lateral_direction")),
     warn_ellipse_size_lateral_direction(
       node->declare_parameter<double>("diagnostics.warn_ellipse_size_lateral_direction")),
+    diagnostics_publish_frequency(
+      node->declare_parameter<double>("diagnostics.diagnostics_publish_frequency")),
+    diagnostics_publish_period(1.0 / diagnostics_publish_frequency),
     threshold_observable_velocity_mps(
       node->declare_parameter<double>("misc.threshold_observable_velocity_mps"))
   {
   }
 
   const bool show_debug_info;
-  const double ekf_rate;
-  const double ekf_dt;
+  const double ekf_rate;  // ekf update frequency = predict_frequency [Hz]
+  const double ekf_dt;    // ekf update period [s]
   const double tf_rate_;
   const bool enable_yaw_bias_estimation;
   const size_t extend_state_step;
@@ -99,6 +102,8 @@ public:
   double warn_ellipse_size;
   double error_ellipse_size_lateral_direction;
   double warn_ellipse_size_lateral_direction;
+  const double diagnostics_publish_frequency;  //!< @brief diagnostics publish frequency [Hz]
+  const double diagnostics_publish_period;     //!< @brief diagnostics publish period [s]
 
   const double threshold_observable_velocity_mps;
 };

--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -29,6 +29,7 @@
   <depend>autoware_utils_logging</depend>
   <depend>autoware_utils_system</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
+++ b/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
@@ -4,6 +4,7 @@
   "definitions": {
     "diagnostics": {
       "type": "object",
+      "description": "Thresholds for per-check diagnostic status and the diagnostic_updater publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. diagnostic_updater publishes /diagnostics at 1/diagnostics_publish_frequency [s], and may publish immediately when merged severity increases versus the previous EKF tick.",
       "properties": {
         "pose_no_update_count_threshold_warn": {
           "type": "integer",
@@ -49,6 +50,12 @@
           "type": "number",
           "description": "The lateral direction size of the error ellipse to trigger a WARN state",
           "default": 0.25
+        },
+        "diagnostics_publish_frequency": {
+          "type": "number",
+          "description": "Diagnostics publish frequency [Hz] for diagnostic_updater::Updater (period = 1/frequency). Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
+          "default": 10.0,
+          "exclusiveMinimum": 0
         }
       },
       "required": [

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -27,11 +27,10 @@
 #include <fmt/core.h>
 
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <memory>
-#include <queue>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::ekf_localizer
@@ -52,10 +51,23 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   params_(this),
   ekf_dt_(params_.ekf_dt),
   pose_queue_(params_.pose_smoothing_steps),
-  twist_queue_(params_.twist_smoothing_steps)
+  twist_queue_(params_.twist_smoothing_steps),
+  diagnostics_(this),
+  merged_diagnostic_last_transition_time_(0, 0, RCL_ROS_TIME),
+  last_pose_callback_time_(0, 0, RCL_ROS_TIME),
+  last_twist_callback_time_(0, 0, RCL_ROS_TIME)
 {
   is_activated_ = false;
   is_set_initialpose_ = false;
+  merged_diagnostic_status_.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  merged_diagnostic_status_.message = "OK";
+
+  // Configure diagnostic updater
+  diagnostics_.setHardwareID(this->get_name());
+  diagnostics_.setPeriod(rclcpp::Duration::from_seconds(params_.diagnostics_publish_period));
+  diagnostics_.add("ekf_localizer", this, &EKFLocalizer::diagnose);
+  diagnostics_.add("callback_pose", this, &EKFLocalizer::diagnose_callback_pose);
+  diagnostics_.add("callback_twist", this, &EKFLocalizer::diagnose_callback_twist);
 
   /* initialize ros system */
   timer_control_ = rclcpp::create_timer(
@@ -74,7 +86,6 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   pub_biased_pose_ = create_publisher<geometry_msgs::msg::PoseStamped>("ekf_biased_pose", 1);
   pub_biased_pose_cov_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "ekf_biased_pose_with_covariance", 1);
-  pub_diag_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
   pub_processing_time_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", 1);
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -140,17 +151,28 @@ void EKFLocalizer::timer_callback()
 
   const rclcpp::Time current_time = this->now();
 
+  // Initialize diagnostic status array to collect diagnostics during processing
+  std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
+
+  // Check process activation status
+  diag_status_array.push_back(check_process_activated(is_activated_));
+
   if (!is_activated_) {
     warning_->warn_throttle(
       "The node is not activated. Provide initial pose to pose_initializer", 2000);
-    publish_diagnostics(geometry_msgs::msg::PoseStamped{}, current_time);
+    // Update diagnostics before early return to ensure current status is latched
+    update_diagnostics(diag_status_array, current_time);
     return;
   }
+
+  // Check initial pose status
+  diag_status_array.push_back(check_set_initialpose(is_set_initialpose_));
 
   if (!is_set_initialpose_) {
     warning_->warn_throttle(
       "Initial pose is not set. Provide initial pose to pose_initializer", 2000);
-    publish_diagnostics(geometry_msgs::msg::PoseStamped{}, current_time);
+    // Update diagnostics before early return to ensure current status is latched
+    update_diagnostics(diag_status_array, current_time);
     return;
   }
 
@@ -195,6 +217,18 @@ void EKFLocalizer::timer_callback()
   }
   pose_diag_info_.no_update_count = pose_is_updated ? 0 : (pose_diag_info_.no_update_count + 1);
 
+  // Add pose-related diagnostics after pose processing
+  diag_status_array.push_back(check_measurement_updated(
+    "pose", pose_diag_info_.no_update_count, params_.pose_no_update_count_threshold_warn,
+    params_.pose_no_update_count_threshold_error));
+  diag_status_array.push_back(check_measurement_queue_size("pose", pose_diag_info_.queue_size));
+  diag_status_array.push_back(check_measurement_delay_gate(
+    "pose", pose_diag_info_.is_passed_delay_gate, pose_diag_info_.delay_time,
+    pose_diag_info_.delay_time_threshold));
+  diag_status_array.push_back(check_measurement_mahalanobis_gate(
+    "pose", pose_diag_info_.is_passed_mahalanobis_gate, pose_diag_info_.mahalanobis_distance,
+    params_.pose_gate_dist));
+
   /* twist measurement update */
   twist_diag_info_.queue_size = twist_queue_.size();
   twist_diag_info_.is_passed_delay_gate = true;
@@ -225,6 +259,18 @@ void EKFLocalizer::timer_callback()
   }
   twist_diag_info_.no_update_count = twist_is_updated ? 0 : (twist_diag_info_.no_update_count + 1);
 
+  // Add twist-related diagnostics after twist processing
+  diag_status_array.push_back(check_measurement_updated(
+    "twist", twist_diag_info_.no_update_count, params_.twist_no_update_count_threshold_warn,
+    params_.twist_no_update_count_threshold_error));
+  diag_status_array.push_back(check_measurement_queue_size("twist", twist_diag_info_.queue_size));
+  diag_status_array.push_back(check_measurement_delay_gate(
+    "twist", twist_diag_info_.is_passed_delay_gate, twist_diag_info_.delay_time,
+    twist_diag_info_.delay_time_threshold));
+  diag_status_array.push_back(check_measurement_mahalanobis_gate(
+    "twist", twist_diag_info_.is_passed_mahalanobis_gate, twist_diag_info_.mahalanobis_distance,
+    params_.twist_gate_dist));
+
   const geometry_msgs::msg::PoseStamped current_ekf_pose =
     ekf_module_->get_current_pose(current_time, false);
   const geometry_msgs::msg::PoseStamped current_biased_ekf_pose =
@@ -232,9 +278,25 @@ void EKFLocalizer::timer_callback()
   const geometry_msgs::msg::TwistStamped current_ekf_twist =
     ekf_module_->get_current_twist(current_time);
 
+  // Calculate covariance ellipse and add diagnostics
+  geometry_msgs::msg::PoseWithCovariance pose_cov;
+  pose_cov.pose = current_ekf_pose.pose;
+  pose_cov.covariance = ekf_module_->get_current_pose_covariance();
+  const autoware::localization_util::Ellipse ellipse =
+    autoware::localization_util::calculate_xy_ellipse(pose_cov, params_.ellipse_scale);
+  diag_status_array.push_back(check_covariance_ellipse(
+    "cov_ellipse_long_axis", ellipse.long_radius, params_.warn_ellipse_size,
+    params_.error_ellipse_size));
+  diag_status_array.push_back(check_covariance_ellipse(
+    "cov_ellipse_lateral_direction", ellipse.size_lateral_direction,
+    params_.warn_ellipse_size_lateral_direction, params_.error_ellipse_size_lateral_direction));
+
   /* publish ekf result */
   publish_estimate_result(current_ekf_pose, current_biased_ekf_pose, current_ekf_twist);
-  publish_diagnostics(current_ekf_pose, current_time);
+
+  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostic_updater,
+   * plus force_update() inside update_diagnostics when severity increases. */
+  update_diagnostics(diag_status_array, current_time);
 
   /* publish processing time */
   const double elapsed_time = stop_watch_timer_cb_.toc();
@@ -292,7 +354,7 @@ void EKFLocalizer::callback_pose_with_covariance(
 
   pose_queue_.push(msg);
 
-  publish_callback_return_diagnostics("pose", msg->header.stamp);
+  last_pose_callback_time_ = msg->header.stamp;
 }
 
 /*
@@ -308,7 +370,7 @@ void EKFLocalizer::callback_twist_with_covariance(
   }
   twist_queue_.push(msg);
 
-  publish_callback_return_diagnostics("twist", msg->header.stamp);
+  last_twist_callback_time_ = msg->header.stamp;
 }
 
 /*
@@ -367,78 +429,79 @@ void EKFLocalizer::publish_estimate_result(
   tf_br_->sendTransform(transform_stamped);
 }
 
-void EKFLocalizer::publish_diagnostics(
-  const geometry_msgs::msg::PoseStamped & current_ekf_pose, const rclcpp::Time & current_time)
+void EKFLocalizer::diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
+  // merged_diagnostic_status_ is updated in update_diagnostics() each EKF tick. Publishing is
+  // driven by diagnostic_updater at diagnostics_publish_period, or force_update() on severity
+  // increase vs. the previous tick.
+  //
+  // Thread safety: copy first for a consistent snapshot if a multi-threaded executor is used.
+  const diagnostic_msgs::msg::DiagnosticStatus snapshot = merged_diagnostic_status_;
 
-  diag_status_array.push_back(check_process_activated(is_activated_));
-  diag_status_array.push_back(check_set_initialpose(is_set_initialpose_));
+  stat.name = "localization: " + std::string(this->get_name());
+  stat.hardware_id = this->get_name();
+  stat.summary(snapshot);
 
-  if (is_activated_ && is_set_initialpose_) {
-    diag_status_array.push_back(check_measurement_updated(
-      "pose", pose_diag_info_.no_update_count, params_.pose_no_update_count_threshold_warn,
-      params_.pose_no_update_count_threshold_error));
-    diag_status_array.push_back(check_measurement_queue_size("pose", pose_diag_info_.queue_size));
-    diag_status_array.push_back(check_measurement_delay_gate(
-      "pose", pose_diag_info_.is_passed_delay_gate, pose_diag_info_.delay_time,
-      pose_diag_info_.delay_time_threshold));
-    diag_status_array.push_back(check_measurement_mahalanobis_gate(
-      "pose", pose_diag_info_.is_passed_mahalanobis_gate, pose_diag_info_.mahalanobis_distance,
-      params_.pose_gate_dist));
-
-    diag_status_array.push_back(check_measurement_updated(
-      "twist", twist_diag_info_.no_update_count, params_.twist_no_update_count_threshold_warn,
-      params_.twist_no_update_count_threshold_error));
-    diag_status_array.push_back(check_measurement_queue_size("twist", twist_diag_info_.queue_size));
-    diag_status_array.push_back(check_measurement_delay_gate(
-      "twist", twist_diag_info_.is_passed_delay_gate, twist_diag_info_.delay_time,
-      twist_diag_info_.delay_time_threshold));
-    diag_status_array.push_back(check_measurement_mahalanobis_gate(
-      "twist", twist_diag_info_.is_passed_mahalanobis_gate, twist_diag_info_.mahalanobis_distance,
-      params_.twist_gate_dist));
-
-    geometry_msgs::msg::PoseWithCovariance pose_cov;
-    pose_cov.pose = current_ekf_pose.pose;
-    pose_cov.covariance = ekf_module_->get_current_pose_covariance();
-    const autoware::localization_util::Ellipse ellipse =
-      autoware::localization_util::calculate_xy_ellipse(pose_cov, params_.ellipse_scale);
-    diag_status_array.push_back(check_covariance_ellipse(
-      "cov_ellipse_long_axis", ellipse.long_radius, params_.warn_ellipse_size,
-      params_.error_ellipse_size));
-    diag_status_array.push_back(check_covariance_ellipse(
-      "cov_ellipse_lateral_direction", ellipse.size_lateral_direction,
-      params_.warn_ellipse_size_lateral_direction, params_.error_ellipse_size_lateral_direction));
+  for (const auto & value : snapshot.values) {
+    stat.add(value.key, value.value);
   }
+}
+
+void EKFLocalizer::diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  stat.name = "localization: " + std::string(this->get_name()) + ": callback_pose";
+  stat.hardware_id = this->get_name();
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+  stat.add("topic_time_stamp", std::to_string(last_pose_callback_time_.nanoseconds()));
+}
+
+void EKFLocalizer::diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  stat.name = "localization: " + std::string(this->get_name()) + ": callback_twist";
+  stat.hardware_id = this->get_name();
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+  stat.add("topic_time_stamp", std::to_string(last_twist_callback_time_.nanoseconds()));
+}
+
+void EKFLocalizer::update_diagnostics(
+  const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & diag_status_array,
+  const rclcpp::Time & current_time)
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+
+  const uint8_t level_before = merged_diagnostic_status_.level;
 
   diagnostic_msgs::msg::DiagnosticStatus diag_merged_status;
   diag_merged_status = merge_diagnostic_status(diag_status_array);
-  diag_merged_status.name = "localization: " + std::string(this->get_name());
-  diag_merged_status.hardware_id = this->get_name();
+  const uint8_t level_merged = diag_merged_status.level;
 
-  diagnostic_msgs::msg::DiagnosticArray diag_msg;
-  diag_msg.header.stamp = current_time;
-  diag_msg.status.push_back(diag_merged_status);
-  pub_diag_->publish(diag_msg);
-}
+  // merged_diagnostic_status_ always tracks merge: ERROR→WARN when merge worst is WARN,
+  // ERROR/WARN→OK when merge is all OK, same level refreshes message/values.
+  merged_diagnostic_status_ = diag_merged_status;
+  // last_transition_time: any level change; force_update below: severity increase only
+  if (level_merged != level_before) {
+    merged_diagnostic_last_transition_time_ = current_time;
+  }
 
-void EKFLocalizer::publish_callback_return_diagnostics(
-  const std::string & callback_name, const rclcpp::Time & current_time)
-{
-  diagnostic_msgs::msg::KeyValue key_value;
-  key_value.key = "topic_time_stamp";
-  key_value.value = std::to_string(current_time.nanoseconds());
-  diagnostic_msgs::msg::DiagnosticStatus diag_status;
-  diag_status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  diag_status.name =
-    "localization: " + std::string(this->get_name()) + ": callback_" + callback_name;
-  diag_status.hardware_id = this->get_name();
-  diag_status.message = "OK";
-  diag_status.values.push_back(key_value);
-  diagnostic_msgs::msg::DiagnosticArray diag_msg;
-  diag_msg.header.stamp = current_time;
-  diag_msg.status.push_back(diag_status);
-  pub_diag_->publish(diag_msg);
+  // Remove transition timestamp keys if present (re-added below when we have a stored time)
+  merged_diagnostic_status_.values.erase(
+    std::remove_if(
+      merged_diagnostic_status_.values.begin(), merged_diagnostic_status_.values.end(),
+      [](const diagnostic_msgs::msg::KeyValue & kv) {
+        return kv.key == "last_level_transition_timestamp";
+      }),
+    merged_diagnostic_status_.values.end());
+
+  if (merged_diagnostic_last_transition_time_.nanoseconds() != 0) {
+    diagnostic_msgs::msg::KeyValue transition_ts;
+    transition_ts.key = "last_level_transition_timestamp";
+    transition_ts.value = std::to_string(merged_diagnostic_last_transition_time_.nanoseconds());
+    merged_diagnostic_status_.values.push_back(transition_ts);
+  }
+
+  if (level_merged > level_before) {
+    diagnostics_.force_update();
+  }
 }
 
 /**

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -12,11 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/localization_util/covariance_ellipse.hpp"
 #include "autoware/ekf_localizer/diagnostics.hpp"
+#include "autoware/ekf_localizer/ekf_localizer.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace autoware::ekf_localizer
@@ -52,7 +63,7 @@ TEST(TestEkfDiagnostics, check_measurement_updated)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
-  const std::string measurement_type = "pose";  // not effect for stat.level
+  const std::string measurement_type = "pose";  // no effect for stat.level
   const size_t no_update_count_threshold_warn = 50;
   const size_t no_update_count_threshold_error = 250;
 
@@ -97,13 +108,13 @@ TEST(TestEkfDiagnostics, check_measurement_queue_size)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
-  const std::string measurement_type = "pose";  // not effect for stat.level
+  const std::string measurement_type = "pose";  // no effect for stat.level
 
-  size_t queue_size = 0;  // not effect for stat.level
+  size_t queue_size = 0;  // no effect for stat.level
   stat = check_measurement_queue_size(measurement_type, queue_size);
   EXPECT_EQ(stat.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
 
-  queue_size = 1;  // not effect for stat.level
+  queue_size = 1;  // no effect for stat.level
   stat = check_measurement_queue_size(measurement_type, queue_size);
   EXPECT_EQ(stat.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
 }
@@ -112,9 +123,9 @@ TEST(TestEkfDiagnostics, check_measurement_delay_gate)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
-  const std::string measurement_type = "pose";  // not effect for stat.level
-  const double delay_time = 0.1;                // not effect for stat.level
-  const double delay_time_threshold = 1.0;      // not effect for stat.level
+  const std::string measurement_type = "pose";  // no effect for stat.level
+  const double delay_time = 0.1;                // no effect for stat.level
+  const double delay_time_threshold = 1.0;      // no effect for stat.level
 
   bool is_passed_delay_gate = true;
   stat = check_measurement_delay_gate(
@@ -131,9 +142,9 @@ TEST(TestEkfDiagnostics, check_measurement_mahalanobis_gate)
 {
   diagnostic_msgs::msg::DiagnosticStatus stat;
 
-  const std::string measurement_type = "pose";        // not effect for stat.level
-  const double mahalanobis_distance = 0.1;            // not effect for stat.level
-  const double mahalanobis_distance_threshold = 1.0;  // not effect for stat.level
+  const std::string measurement_type = "pose";        // no effect for stat.level
+  const double mahalanobis_distance = 0.1;            // no effect for stat.level
+  const double mahalanobis_distance_threshold = 1.0;  // no effect for stat.level
 
   bool is_passed_mahalanobis_gate = true;
   stat = check_measurement_mahalanobis_gate(
@@ -148,7 +159,7 @@ TEST(TestEkfDiagnostics, check_measurement_mahalanobis_gate)
   EXPECT_EQ(stat.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
 }
 
-TEST(TestLocalizationErrorMonitorDiagnostics, merge_diagnostic_status)
+TEST(TestEkfDiagnostics, merge_diagnostic_status)
 {
   diagnostic_msgs::msg::DiagnosticStatus merged_stat;
   std::vector<diagnostic_msgs::msg::DiagnosticStatus> stat_array(2);
@@ -208,6 +219,940 @@ TEST(TestLocalizationErrorMonitorDiagnostics, merge_diagnostic_status)
   merged_stat = merge_diagnostic_status(stat_array);
   EXPECT_EQ(merged_stat.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
   EXPECT_EQ(merged_stat.message, "ERROR0; ERROR1");
+}
+
+// Friend class to access private members of EKFLocalizer for testing
+class EKFLocalizerDiagnosticsTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  void TearDown() override
+  {
+    // Don't shutdown here as other tests might need rclcpp context
+  }
+
+  static rclcpp::NodeOptions make_ekf_localizer_options(
+    double diagnostics_publish_frequency, double ekf_rate)
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+      // Node parameters
+      {"node.show_debug_info", false},
+      {"node.enable_yaw_bias_estimation", true},
+      {"node.predict_frequency", ekf_rate},
+      {"node.tf_rate", 50.0},
+      {"node.extend_state_step", 50},
+      // Pose measurement parameters
+      {"pose_measurement.pose_additional_delay", 0.0},
+      {"pose_measurement.pose_measure_uncertainty_time", 0.01},
+      {"pose_measurement.pose_smoothing_steps", 5},
+      {"pose_measurement.max_pose_queue_size", 5},
+      {"pose_measurement.pose_gate_dist", 49.5},
+      // Twist measurement parameters
+      {"twist_measurement.twist_additional_delay", 0.0},
+      {"twist_measurement.twist_smoothing_steps", 2},
+      {"twist_measurement.max_twist_queue_size", 2},
+      {"twist_measurement.twist_gate_dist", 46.1},
+      // Process noise parameters
+      {"process_noise.proc_stddev_yaw_c", 0.005},
+      {"process_noise.proc_stddev_vx_c", 10.0},
+      {"process_noise.proc_stddev_wz_c", 5.0},
+      // Simple 1D filter parameters
+      {"simple_1d_filter_parameters.z_filter_proc_dev", 5.0},
+      {"simple_1d_filter_parameters.roll_filter_proc_dev", 0.1},
+      {"simple_1d_filter_parameters.pitch_filter_proc_dev", 0.1},
+      // Diagnostics parameters
+      {"diagnostics.pose_no_update_count_threshold_warn", 50},
+      {"diagnostics.pose_no_update_count_threshold_error", 100},
+      {"diagnostics.twist_no_update_count_threshold_warn", 50},
+      {"diagnostics.twist_no_update_count_threshold_error", 100},
+      {"diagnostics.ellipse_scale", 3.0},
+      {"diagnostics.error_ellipse_size", 1.5},
+      {"diagnostics.warn_ellipse_size", 1.2},
+      {"diagnostics.error_ellipse_size_lateral_direction", 0.3},
+      {"diagnostics.warn_ellipse_size_lateral_direction", 0.25},
+      {"diagnostics.diagnostics_publish_frequency", diagnostics_publish_frequency},
+      // Misc parameters
+      {"misc.threshold_observable_velocity_mps", 0.0},
+      {"misc.pose_frame_id", "map"},
+    });
+    return options;
+  }
+
+  static std::shared_ptr<autoware::ekf_localizer::EKFLocalizer> create_ekf_localizer(
+    double diagnostics_publish_period, double ekf_rate)
+  {
+    return std::make_shared<autoware::ekf_localizer::EKFLocalizer>(
+      make_ekf_localizer_options(1.0 / diagnostics_publish_period, ekf_rate));
+  }
+
+  // Helper methods to access private members through friend class
+
+  static void update_diagnostics(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer,
+    const geometry_msgs::msg::PoseStamped & current_ekf_pose, const rclcpp::Time & current_time)
+  {
+    // Create diagnostic status array similar to timer_callback
+    std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
+
+    // Check process activation status
+    diag_status_array.push_back(check_process_activated(ekf_localizer->is_activated_));
+
+    // Check initial pose status
+    diag_status_array.push_back(check_set_initialpose(ekf_localizer->is_set_initialpose_));
+
+    // Add diagnostics for pose and twist if activated and initial pose is set
+    if (ekf_localizer->is_activated_ && ekf_localizer->is_set_initialpose_) {
+      diag_status_array.push_back(check_measurement_updated(
+        "pose", ekf_localizer->pose_diag_info_.no_update_count,
+        ekf_localizer->params_.pose_no_update_count_threshold_warn,
+        ekf_localizer->params_.pose_no_update_count_threshold_error));
+      diag_status_array.push_back(
+        check_measurement_queue_size("pose", ekf_localizer->pose_diag_info_.queue_size));
+      diag_status_array.push_back(check_measurement_delay_gate(
+        "pose", ekf_localizer->pose_diag_info_.is_passed_delay_gate,
+        ekf_localizer->pose_diag_info_.delay_time,
+        ekf_localizer->pose_diag_info_.delay_time_threshold));
+      diag_status_array.push_back(check_measurement_mahalanobis_gate(
+        "pose", ekf_localizer->pose_diag_info_.is_passed_mahalanobis_gate,
+        ekf_localizer->pose_diag_info_.mahalanobis_distance,
+        ekf_localizer->params_.pose_gate_dist));
+
+      diag_status_array.push_back(check_measurement_updated(
+        "twist", ekf_localizer->twist_diag_info_.no_update_count,
+        ekf_localizer->params_.twist_no_update_count_threshold_warn,
+        ekf_localizer->params_.twist_no_update_count_threshold_error));
+      diag_status_array.push_back(
+        check_measurement_queue_size("twist", ekf_localizer->twist_diag_info_.queue_size));
+      diag_status_array.push_back(check_measurement_delay_gate(
+        "twist", ekf_localizer->twist_diag_info_.is_passed_delay_gate,
+        ekf_localizer->twist_diag_info_.delay_time,
+        ekf_localizer->twist_diag_info_.delay_time_threshold));
+      diag_status_array.push_back(check_measurement_mahalanobis_gate(
+        "twist", ekf_localizer->twist_diag_info_.is_passed_mahalanobis_gate,
+        ekf_localizer->twist_diag_info_.mahalanobis_distance,
+        ekf_localizer->params_.twist_gate_dist));
+
+      // Calculate covariance ellipse and add diagnostics
+      geometry_msgs::msg::PoseWithCovariance pose_cov;
+      pose_cov.pose = current_ekf_pose.pose;
+      pose_cov.covariance = ekf_localizer->ekf_module_->get_current_pose_covariance();
+      const autoware::localization_util::Ellipse ellipse =
+        autoware::localization_util::calculate_xy_ellipse(
+          pose_cov, ekf_localizer->params_.ellipse_scale);
+      diag_status_array.push_back(check_covariance_ellipse(
+        "cov_ellipse_long_axis", ellipse.long_radius, ekf_localizer->params_.warn_ellipse_size,
+        ekf_localizer->params_.error_ellipse_size));
+      diag_status_array.push_back(check_covariance_ellipse(
+        "cov_ellipse_lateral_direction", ellipse.size_lateral_direction,
+        ekf_localizer->params_.warn_ellipse_size_lateral_direction,
+        ekf_localizer->params_.error_ellipse_size_lateral_direction));
+    }
+
+    ekf_localizer->update_diagnostics(diag_status_array, current_time);
+  }
+
+  static void update_diagnostics_raw(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer,
+    const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & diag_status_array,
+    const rclcpp::Time & current_time)
+  {
+    ekf_localizer->update_diagnostics(diag_status_array, current_time);
+  }
+
+  /** Only activation and initial-pose checks (merged OK) — for tests that need merged status OK. */
+  static void update_diagnostics_activation_and_initialpose_only(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer, const rclcpp::Time & current_time)
+  {
+    std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
+    diag_status_array.push_back(check_process_activated(ekf_localizer->is_activated_));
+    diag_status_array.push_back(check_set_initialpose(ekf_localizer->is_set_initialpose_));
+    ekf_localizer->update_diagnostics(diag_status_array, current_time);
+  }
+
+  static diagnostic_msgs::msg::DiagnosticStatus get_merged_diagnostic_status(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
+  {
+    return ekf_localizer->merged_diagnostic_status_;
+  }
+
+  static rclcpp::Time get_merged_diagnostic_last_transition_time(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
+  {
+    return ekf_localizer->merged_diagnostic_last_transition_time_;
+  }
+
+  static void set_pose_diag_info_no_update_count(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer, size_t count)
+  {
+    ekf_localizer->pose_diag_info_.no_update_count = count;
+  }
+
+  static void set_is_activated(autoware::ekf_localizer::EKFLocalizer * ekf_localizer, bool value)
+  {
+    ekf_localizer->is_activated_ = value;
+  }
+
+  static void set_is_set_initialpose(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer, bool value)
+  {
+    ekf_localizer->is_set_initialpose_ = value;
+  }
+
+  static void initialize_ekf_module(
+    autoware::ekf_localizer::EKFLocalizer * ekf_localizer,
+    const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose)
+  {
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.stamp = initial_pose.header.stamp;
+    transform.header.frame_id = "map";
+    transform.child_frame_id = initial_pose.header.frame_id;
+    transform.transform.translation.x = 0.0;
+    transform.transform.translation.y = 0.0;
+    transform.transform.translation.z = 0.0;
+    transform.transform.rotation.w = 1.0;
+    transform.transform.rotation.x = 0.0;
+    transform.transform.rotation.y = 0.0;
+    transform.transform.rotation.z = 0.0;
+    ekf_localizer->ekf_module_->initialize(initial_pose, transform);
+  }
+
+  static void force_diagnostics_update(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
+  {
+    ekf_localizer->diagnostics_.force_update();
+  }
+
+  static void call_timer_callback(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
+  {
+    ekf_localizer->timer_callback();
+  }
+};
+
+// Note: Tests for should_publish_diagnostics() are removed because
+// diagnostic_updater::Updater now handles the period control internally.
+// The period is set via setPeriod() and the updater automatically calls
+// diagnose() at the configured interval.
+
+TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_reflects_pose_no_update_warn_then_error)
+{
+  // Merged diagnostic reflects pose no-update WARN then ERROR as stale count crosses thresholds.
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  // Initialize ekf_module_ to avoid covariance ellipse errors
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  // Set small covariance to avoid ellipse errors
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+
+  // Set activated and initialpose to true to enable pose diagnostics
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  // Initially merged status should be OK
+  auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+
+  // Simulate WARN condition: pose not updated for threshold_warn count
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 50);  // threshold_warn = 50
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should be WARN (or ERROR if covariance ellipse check fails)
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  // Note: If covariance ellipse check returns ERROR, merged status will be ERROR
+  // So we check that the level is at least WARN
+  EXPECT_GE(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  // Verify that pose error message is included (may be merged with covariance error)
+  EXPECT_TRUE(
+    merged_status.message.find("pose is not updated") != std::string::npos ||
+    merged_status.message.find("cov_ellipse") != std::string::npos);
+
+  // Simulate ERROR condition: pose not updated for threshold_error count
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 100);  // threshold_error = 100
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should be ERROR
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+  EXPECT_TRUE(merged_status.message.find("pose is not updated") != std::string::npos);
+
+  // Verify last_level_transition_timestamp is added
+  bool has_timestamp = false;
+  for (const auto & value : merged_status.values) {
+    if (value.key == "last_level_transition_timestamp") {
+      has_timestamp = true;
+      EXPECT_EQ(
+        value.value,
+        std::to_string(
+          get_merged_diagnostic_last_transition_time(ekf_localizer.get()).nanoseconds()));
+      break;
+    }
+  }
+  EXPECT_TRUE(has_timestamp);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, update_diagnostics_deescalates_error_to_warn_when_merge_warn)
+{
+  // ERROR→WARN when merge worst is WARN (covariance ellipse etc. omitted — controlled merge).
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  const size_t thr_w = 50;
+  const size_t thr_e = 100;
+
+  std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag;
+  diag.push_back(check_process_activated(true));
+  diag.push_back(check_set_initialpose(true));
+  diag.push_back(check_measurement_updated("pose", thr_e, thr_w, thr_e));  // ERROR
+  diag.push_back(check_measurement_updated("twist", 0, thr_w, thr_e));
+  update_diagnostics_raw(ekf_localizer.get(), diag, current_time);
+  auto merged_status_before = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status_before.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  diag.clear();
+  diag.push_back(check_process_activated(true));
+  diag.push_back(check_set_initialpose(true));
+  diag.push_back(check_measurement_updated("pose", thr_w, thr_w, thr_e));  // WARN
+  diag.push_back(check_measurement_updated("twist", 0, thr_w, thr_e));
+  update_diagnostics_raw(ekf_localizer.get(), diag, current_time);
+
+  auto merged_status_after = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status_after.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_TRUE(merged_status_after.message.find("pose is not updated") != std::string::npos);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_updates_when_previous_merge_was_ok)
+{
+  // When previous merged status was OK, the next update_diagnostics reflects new severity
+  // (OK→WARN).
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  // Initialize ekf_module_ to avoid covariance ellipse errors
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  // Set small covariance to avoid ellipse errors
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+
+  // Set activated and initialpose to true to enable pose diagnostics
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  // Initially merged status should be OK
+  auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+
+  // Update with OK status
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 0);
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should remain OK (or ERROR if covariance ellipse check fails)
+  // Note: If covariance ellipse check returns ERROR, merged status will be ERROR
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  // If covariance ellipse check fails, level might be ERROR, but we check that it's at least OK
+  EXPECT_GE(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+
+  // Update with WARN status (when previous merge was OK, merged status should update)
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 50);  // threshold_warn = 50
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should be WARN (or ERROR if covariance ellipse check fails)
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  // Note: If covariance ellipse check returns ERROR, merged status will be ERROR
+  // So we check that the level is at least WARN
+  EXPECT_GE(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  // Verify that pose error message is included (may be merged with covariance error)
+  EXPECT_TRUE(
+    merged_status.message.find("pose is not updated") != std::string::npos ||
+    merged_status.message.find("cov_ellipse") != std::string::npos);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_when_only_activation_and_initialpose_ok)
+{
+  // Minimal OK merge (activation + initial pose only) sets merged diagnostic to OK even after ERROR
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 100);  // threshold_error = 100
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+  auto merged_status_before = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_GE(merged_status_before.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  // Full pose/ellipse merge may stay non-OK; activation-only merge must yield OK merged status
+  update_diagnostics_activation_and_initialpose_only(ekf_localizer.get(), current_time);
+
+  auto merged_status_after = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status_after.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(merged_status_after.message, "OK");
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_after_force_update_and_minimal_merge)
+{
+  // After force_update(), activation-only update_diagnostics sets merged status to OK (no special
+  // reset path)
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  // Initialize ekf_module_
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  // Merged ERROR from pose no-update
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 100);  // threshold_error = 100
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+  auto merged_status_before = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_GE(merged_status_before.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  force_diagnostics_update(ekf_localizer.get());
+
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 0);
+  // Next update_diagnostics with minimal OK merge (as after a publish tick)
+  update_diagnostics_activation_and_initialpose_only(ekf_localizer.get(), current_time);
+
+  auto merged_status_after = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status_after.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+  EXPECT_EQ(merged_status_after.message, "OK");
+  bool found_transition_ts = false;
+  for (const auto & kv : merged_status_after.values) {
+    EXPECT_NE(kv.key, "error_occurrence_timestamp");
+    if (kv.key == "last_level_transition_timestamp") {
+      EXPECT_FALSE(found_transition_ts);
+      found_transition_ts = true;
+      EXPECT_EQ(
+        kv.value, std::to_string(
+                    get_merged_diagnostic_last_transition_time(ekf_localizer.get()).nanoseconds()));
+      EXPECT_EQ(
+        get_merged_diagnostic_last_transition_time(ekf_localizer.get()).nanoseconds(),
+        current_time.nanoseconds());
+    }
+  }
+  EXPECT_TRUE(found_transition_ts);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, last_level_transition_timestamp_when_non_ok)
+{
+  // last_level_transition_timestamp KeyValue matches merged_diagnostic_last_transition_time_
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time error_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = error_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  // Initialize ekf_module_
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = error_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  // Merged ERROR from pose no-update
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 100);  // threshold_error = 100
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, error_time);
+
+  auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_GE(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
+
+  bool has_timestamp = false;
+  std::string timestamp_value;
+  for (const auto & value : merged_status.values) {
+    if (value.key == "last_level_transition_timestamp") {
+      has_timestamp = true;
+      timestamp_value = value.value;
+      break;
+    }
+  }
+  EXPECT_TRUE(has_timestamp);
+  EXPECT_EQ(
+    timestamp_value,
+    std::to_string(get_merged_diagnostic_last_transition_time(ekf_localizer.get()).nanoseconds()));
+
+  // Verify timestamp matches the error time
+  EXPECT_EQ(
+    get_merged_diagnostic_last_transition_time(ekf_localizer.get()).nanoseconds(),
+    error_time.nanoseconds());
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_updated_when_not_activated)
+{
+  // Test that diagnostics are updated even when is_activated_ is false (early return case)
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+
+  // Ensure is_activated_ is false
+  set_is_activated(ekf_localizer.get(), false);
+  set_is_set_initialpose(ekf_localizer.get(), false);
+
+  // Update diagnostics (simulating early return in timer_callback)
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should reflect that process is not activated (WARN)
+  auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_TRUE(merged_status.message.find("process is not activated") != std::string::npos);
+
+  force_diagnostics_update(ekf_localizer.get());
+
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+  update_diagnostics_activation_and_initialpose_only(ekf_localizer.get(), current_time);
+
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_updated_when_initialpose_not_set)
+{
+  // Test that diagnostics are updated even when is_set_initialpose_ is false (early return case)
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+
+  // Set is_activated_ to true but is_set_initialpose_ to false
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), false);
+
+  // Update diagnostics (simulating early return in timer_callback)
+  update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
+
+  // Merged status should reflect that initial pose is not set (WARN)
+  auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_TRUE(merged_status.message.find("initial pose is not set") != std::string::npos);
+
+  force_diagnostics_update(ekf_localizer.get());
+
+  set_is_set_initialpose(ekf_localizer.get(), true);
+  update_diagnostics_activation_and_initialpose_only(ekf_localizer.get(), current_time);
+
+  merged_status = get_merged_diagnostic_status(ekf_localizer.get());
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::OK);
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
+{
+  // When diagnostics_publish_period > 0, diagnostic_updater's internal timer publishes at that
+  // period
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;  // 10 Hz
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  int diag_count = 0;
+  auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&diag_count](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr) { ++diag_count; });
+
+  rclcpp::ExecutorOptions options;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(ekf_localizer);
+
+  const auto spin_duration = std::chrono::milliseconds(250);
+  const auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < spin_duration && rclcpp::ok()) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  executor.remove_node(ekf_localizer);
+
+  EXPECT_GE(diag_count, 1) << "Expected at least one /diagnostics message within 250 ms at 10 Hz";
+}
+
+TEST_F(
+  EKFLocalizerDiagnosticsTest, callback_pose_and_twist_published_at_period_when_period_positive)
+{
+  // When diagnostics_publish_period > 0, callback_pose and callback_twist are published at the
+  // updater period via diagnose_callback_pose and diagnose_callback_twist. This test verifies that
+  // after publishing pose and twist, spinning yields both callback_pose and callback_twist on
+  // /diagnostics at the configured period.
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;  // 10 Hz
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  bool received_callback_pose_diag = false;
+  bool received_callback_twist_diag = false;
+  auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&received_callback_pose_diag,
+     &received_callback_twist_diag](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg) {
+      for (const auto & status : msg->status) {
+        if (status.name.find("callback_pose") != std::string::npos) {
+          received_callback_pose_diag = true;
+        }
+        if (status.name.find("callback_twist") != std::string::npos) {
+          received_callback_twist_diag = true;
+        }
+      }
+    });
+
+  auto pub_pose = ekf_localizer->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "in_pose_with_covariance", 1);
+  auto pub_twist = ekf_localizer->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "in_twist_with_covariance", 1);
+
+  rclcpp::ExecutorOptions options;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(ekf_localizer);
+
+  geometry_msgs::msg::PoseWithCovarianceStamped pose_msg;
+  pose_msg.header.stamp = ekf_localizer->now();
+  pose_msg.header.frame_id = "map";
+  pose_msg.pose.pose.orientation.w = 1.0;
+  pub_pose->publish(pose_msg);
+
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_msg;
+  twist_msg.header.stamp = ekf_localizer->now();
+  twist_msg.header.frame_id = "base_link";
+  pub_twist->publish(twist_msg);
+
+  const auto spin_duration = std::chrono::milliseconds(250);
+  const auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < spin_duration && rclcpp::ok()) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  executor.remove_node(ekf_localizer);
+
+  EXPECT_TRUE(received_callback_pose_diag)
+    << "Expected at least one callback_pose diagnostic at updater period when period > 0";
+  EXPECT_TRUE(received_callback_twist_diag)
+    << "Expected at least one callback_twist diagnostic at updater period when period > 0";
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
+{
+  // Verify diagnostic_updater emits /diagnostics at roughly diagnostics_publish_period.
+  // Feed pose/twist occasionally so merged diagnostics stay OK: otherwise no_update_count rises,
+  // merged status returns OK after each publish, and OK->ERROR repeats every EKF tick (force_update
+  // storm).
+  const double ekf_rate = 50.0;
+  const double diagnostics_publish_period = 0.2;  // 5 Hz
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  auto pub_pose = ekf_localizer->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "in_pose_with_covariance", 10);
+  auto pub_twist = ekf_localizer->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "in_twist_with_covariance", 10);
+
+  geometry_msgs::msg::PoseWithCovarianceStamped pose_feed;
+  pose_feed.header.frame_id = "map";
+  pose_feed.pose = initial_pose.pose;
+
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_feed;
+  twist_feed.header.frame_id = "base_link";
+  twist_feed.twist.twist.linear.x = 0.0;
+  twist_feed.twist.twist.linear.y = 0.0;
+  twist_feed.twist.twist.linear.z = 0.0;
+  twist_feed.twist.twist.angular.z = 0.0;
+  for (size_t i = 0; i < 36; ++i) {
+    twist_feed.twist.covariance[i] = (i == 0 || i == 5 * 6 + 5) ? 0.01 : 0.0;
+  }
+
+  std::vector<std::chrono::steady_clock::time_point> receive_times;
+  auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&receive_times](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr /* msg */) {
+      receive_times.push_back(std::chrono::steady_clock::now());
+    });
+
+  rclcpp::ExecutorOptions options;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(ekf_localizer);
+
+  const double spin_seconds = 1.15;
+  const auto spin_end =
+    std::chrono::steady_clock::now() + std::chrono::duration<double>(spin_seconds);
+  for (size_t iter = 0; std::chrono::steady_clock::now() < spin_end && rclcpp::ok(); ++iter) {
+    if (iter % 15 == 0) {
+      const rclcpp::Time stamp = ekf_localizer->now();
+      pose_feed.header.stamp = stamp;
+      twist_feed.header.stamp = stamp;
+      pub_pose->publish(pose_feed);
+      pub_twist->publish(twist_feed);
+    }
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+
+  executor.remove_node(ekf_localizer);
+
+  const size_t min_expected = static_cast<size_t>(spin_seconds / diagnostics_publish_period) > 2
+                                ? static_cast<size_t>(spin_seconds / diagnostics_publish_period) - 2
+                                : 1;
+  EXPECT_GE(receive_times.size(), min_expected)
+    << "Expected about " << (spin_seconds / diagnostics_publish_period) << " periodic publishes in "
+    << spin_seconds << " s (allowing startup slack)";
+
+  ASSERT_GE(receive_times.size(), 4u)
+    << "Need several messages to check intervals between periodic publishes";
+
+  for (size_t i = 2; i < receive_times.size(); ++i) {
+    const double dt =
+      std::chrono::duration<double>(receive_times[i] - receive_times[i - 1]).count();
+    // Ignore sub-period gaps from diagnostic_updater task registration or batched delivery.
+    if (dt < diagnostics_publish_period * 0.15) {
+      continue;
+    }
+    EXPECT_GE(dt, diagnostics_publish_period * 0.25)
+      << "Consecutive /diagnostics arrived faster than the configured period (too dense)";
+    EXPECT_LE(dt, diagnostics_publish_period * 8.0)
+      << "Consecutive /diagnostics gap too large — periodic publish may be broken";
+  }
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_immediately_on_severity_increase)
+{
+  // With a very long updater period, only force_update() on severity increase should publish.
+  // Slow EKF timer so executor-driven ticks do not merge to ERROR before we inject it.
+  const double ekf_rate = 0.01;
+  const double slow_diagnostics_frequency = 0.01;  // 100 s period
+
+  auto ekf_localizer = std::make_shared<autoware::ekf_localizer::EKFLocalizer>(
+    make_ekf_localizer_options(slow_diagnostics_frequency, ekf_rate));
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  int diag_count = 0;
+  bool saw_error_main_diag = false;
+  auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&diag_count, &saw_error_main_diag](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg) {
+      ++diag_count;
+      for (const auto & st : msg->status) {
+        if (st.name.find("callback_") != std::string::npos) {
+          continue;
+        }
+        if (st.name.find("localization:") == std::string::npos) {
+          continue;
+        }
+        if (st.level >= diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+          saw_error_main_diag = true;
+        }
+      }
+    });
+
+  rclcpp::ExecutorOptions options;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(ekf_localizer);
+
+  for (int i = 0; i < 40 && rclcpp::ok(); ++i) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(3));
+  }
+
+  const int count_before = diag_count;
+
+  saw_error_main_diag = false;
+  set_pose_diag_info_no_update_count(ekf_localizer.get(), 100);
+  call_timer_callback(ekf_localizer.get());
+
+  for (int i = 0; i < 80 && rclcpp::ok(); ++i) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    if (diag_count > count_before) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+
+  executor.remove_node(ekf_localizer);
+
+  EXPECT_GT(diag_count, count_before)
+    << "Severity increase should trigger an immediate /diagnostics publish (force_update) even "
+       "when periodic publish is 100 s away";
+  EXPECT_TRUE(saw_error_main_diag)
+    << "Expected main ekf_localizer diagnostic status to report ERROR after severity increase";
 }
 
 }  // namespace autoware::ekf_localizer


### PR DESCRIPTION
## Description

cherry pick following PRs
https://github.com/autowarefoundation/autoware_core/pull/826

## Notes

- To improve the `/diagnostics` transmission cycle, this change must be applied in conjunction with the following cherry-pick PR.
  - https://github.com/tier4/autoware_universe/pull/2840
  - https://github.com/tier4/autoware_launch.x2/pull/2107
  - https://github.com/tier4/aip_launcher/pull/682
  - https://github.com/tier4/autoware_core/pull/91

## How was this PR tested?

### 1. `/diagnostics` Transmission Frequency

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean Hz | 1,216 Hz | 855 Hz | −30% |
| Std Hz | 171 Hz | 115 Hz | −33% |
| Max Hz | 1,278 Hz | 884 Hz | −31% |

**Analysis:** The transmission frequency decreased by approximately 30%, and variance was reduced. This indicates a lighter input load on the diagnostics pipeline.

---

### 2. Total CPU Utilization

> Combined load of multiple `topic_state_monitor` instances + `aggregator_node`

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean | 47.7% | 33.0% | −14.7 pt (−31%) |
| P50 (Median) | 52.0% | 34.0% | −18.0 pt (−35%) |
| P95 | 62.0% | 44.0% | −18.0 pt (−29%) |
| Max | 70.0% | 50.0% | −20.0 pt (−29%) |
| Std | 13.8% | 8.4% | −39% (Improved Stability) |

**Analysis:** CPU usage was reduced by approximately 30% in both mean and median values. The standard deviation also decreased by about 40%, effectively suppressing load fluctuations.

---

## Overall Summary

The reduction in `/diagnostics` transmission frequency (~30%) is almost directly proportional to the reduction in CPU usage (~30%). This confirms that the high transmission frequency was the primary cause of the CPU load.