### PR TITLE
fix(ndt_scan_matcher): guard input source access with mutex (#991)

### DIFF
--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
@@ -68,6 +68,8 @@
 #include <pcl/registration/registration.h>
 
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -138,11 +140,22 @@ public:
     // This is to avoid segmentation fault when setting null input
     // No idea why PCL does not check the nullity of input
     if (input) {
-      BaseRegType::setInputSource(input);
+      // Deep-copy to avoid data races when the producer mutates the cloud after passing it in.
+      auto copied = std::make_shared<PointCloudSource>(*input);
+      {
+        std::lock_guard<std::mutex> lock(input_source_mutex_);
+        BaseRegType::setInputSource(copied);
+      }
     } else {
       std::cerr << "Error: Null input source cloud is not allowed" << std::endl;
       exit(EXIT_FAILURE);
     }
+  }
+
+  inline PointCloudSourceConstPtr getInputSource()
+  {
+    std::lock_guard<std::mutex> lock(input_source_mutex_);
+    return BaseRegType::getInputSource();
   }
 
   inline void setInputTarget(const PointCloudTargetConstPtr & cloud)
@@ -490,6 +503,8 @@ protected:
   Eigen::Vector3f regularization_pose_translation_;
 
   NdtParams params_;
+
+  mutable std::mutex input_source_mutex_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -120,6 +120,11 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
 MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   const MultiGridNormalDistributionsTransform & other)
 {
+  // Guard self-assignment to avoid unnecessary locking and copying.
+  if (this == &other) {
+    return *this;
+  }
+
   target_cells_ = other.target_cells_;
   params_ = other.params_;
 
@@ -139,6 +144,7 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
 
+  std::scoped_lock<std::mutex, std::mutex> lock(input_source_mutex_, other.input_source_mutex_);
   BaseRegType::operator=(other);
 
   return *this;
@@ -149,6 +155,11 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget> &
 MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   MultiGridNormalDistributionsTransform && other) noexcept
 {
+  // Guard self-assignment to avoid unnecessary locking and copying.
+  if (this == &other) {
+    return *this;
+  }
+
   target_cells_ = std::move(other.target_cells_);
   params_ = std::move(other.params_);
 
@@ -168,6 +179,7 @@ MultiGridNormalDistributionsTransform<PointSource, PointTarget>::operator=(
   regularization_pose_ = other.regularization_pose_;
   regularization_pose_translation_ = other.regularization_pose_translation_;
 
+  std::scoped_lock<std::mutex, std::mutex> lock(input_source_mutex_, other.input_source_mutex_);
   BaseRegType::operator=(std::move(other));
 
   return *this;


### PR DESCRIPTION
Backport https://github.com/tier4/autoware_core/pull/92 to beta/v0.64.
No changes, cherry-picked from beta/x2/v4.3.1.2.