### PR TITLE
feat(motion_utils): add calculate_stop_distance (#849)

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/distance/distance.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/distance/distance.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,18 +15,38 @@
 #ifndef AUTOWARE__MOTION_UTILS__DISTANCE__DISTANCE_HPP_
 #define AUTOWARE__MOTION_UTILS__DISTANCE__DISTANCE_HPP_
 
-#include <algorithm>
-#include <cmath>
-#include <iostream>
 #include <optional>
-#include <tuple>
-#include <vector>
 
 namespace autoware::motion_utils
 {
 [[nodiscard]] std::optional<double> calcDecelDistWithJerkAndAccConstraints(
   const double current_vel, const double target_vel, const double current_acc, const double acc_min,
   const double jerk_acc, const double jerk_dec);
+
+/**
+ * @brief Computes the minimum longitudinal distance required to bring a vehicle to a
+ * complete stop, subject to jerk and acceleration constraints.
+ *
+ * This function models a three-phase stopping profile:
+ * 1. A latency/delay phase where initial acceleration is maintained.
+ * 2. A jerk-limited braking phase where deceleration increases to the maximum limit.
+ * 3. A constant maximum-deceleration phase until the vehicle stops.
+ * * If the vehicle reaches a full stop during phase 1 or phase 2, the calculation
+ * terminates early and returns the exact distance covered up to the point where v = 0.
+ *
+ * @param current_vel        Current longitudinal speed v₀ [m/s].
+ * @param current_acc        Current longitudinal acceleration a₀ [m/s²].
+ * @param decel_limit        Maximum braking deceleration [m/s²]
+ * @param jerk_limit         Maximum braking jerk [m/s³]
+ * @param initial_time_delay Latency before any braking jerk is applied t₁ [s]. Defaults to 0.0.
+ *
+ * @return std::optional<double> Minimum longitudinal stopping distance [m].
+ * Returns 0.0 if the current velocity is already non-positive.
+ * Returns std::nullopt if the kinematic limits are invalid (e.g., limits are 0).
+ */
+[[nodiscard]] std::optional<double> calculate_stop_distance(
+  const double current_vel, const double current_acc, const double acc_limit,
+  const double jerk_limit, const double initial_time_delay = 0.0);
 
 }  // namespace autoware::motion_utils
 

--- a/common/autoware_motion_utils/src/distance/distance.cpp
+++ b/common/autoware_motion_utils/src/distance/distance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +14,15 @@
 
 #include "autoware/motion_utils/distance/distance.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <tuple>
 
 namespace autoware::motion_utils
 {
 namespace
 {
+constexpr double epsilon = 1e-3;
 bool validCheckDecelPlan(
   const double v_end, const double a_end, const double v_target, const double a_target,
   const double v_margin, const double a_margin)
@@ -97,8 +100,6 @@ std::optional<double> calcDecelDistPlanType1(
   const double v0, const double vt, const double a0, const double am, const double ja,
   const double jd, const double t_during_min_acc)
 {
-  constexpr double epsilon = 1e-3;
-
   // negative jerk time
   const double j1 = am < a0 ? jd : ja;
   const double t1 = epsilon < (am - a0) / j1 ? (am - a0) / j1 : 0.0;
@@ -160,8 +161,6 @@ std::optional<double> calcDecelDistPlanType1(
 std::optional<double> calcDecelDistPlanType2(
   const double v0, const double vt, const double a0, const double ja, const double jd)
 {
-  constexpr double epsilon = 1e-3;
-
   const double a1_square = (vt - v0 - 0.5 * (0.0 - a0) / jd * a0) * (2.0 * ja * jd / (ja - jd));
   const double a1 = -std::sqrt(a1_square);
 
@@ -217,8 +216,6 @@ std::optional<double> calcDecelDistPlanType2(
 std::optional<double> calcDecelDistPlanType3(
   const double v0, const double vt, const double a0, const double ja)
 {
-  constexpr double epsilon = 1e-3;
-
   // positive jerk time
   const double t_acc = (0.0 - a0) / ja;
   const double t1 = epsilon < t_acc ? t_acc : 0.0;
@@ -244,7 +241,6 @@ std::optional<double> calcDecelDistWithJerkAndAccConstraints(
     return {};
   }
 
-  constexpr double epsilon = 1e-3;
   const double jerk_before_min_acc = acc_min < current_acc ? jerk_dec : jerk_acc;
   const double t_before_min_acc = (acc_min - current_acc) / jerk_before_min_acc;
   const double jerk_after_min_acc = jerk_acc;
@@ -271,4 +267,66 @@ std::optional<double> calcDecelDistWithJerkAndAccConstraints(
 
   return calcDecelDistPlanType3(current_vel, target_vel, current_acc, jerk_acc);
 }
+
+[[nodiscard]] std::optional<double> calculate_stop_distance(
+  const double v0, const double a0, const double decel_limit, const double jerk_limit,
+  const double initial_time_delay)
+{
+  // already stopped or reversing
+  if (v0 <= 0.0) {
+    return 0.0;
+  }
+
+  // jerk and acceleration limits must be strictly negative to stop a forward-moving vehicle.
+  const auto negative_jerk_limit = -std::abs(jerk_limit);
+  // ensure current_acc respects the deceleration limit, otherwise the maths break down
+  const auto negative_decel_limit = std::min(-std::abs(decel_limit), a0);
+  // using epsilon to prevent division by zero.
+  if (negative_jerk_limit >= -epsilon || negative_decel_limit >= -epsilon) {
+    return std::nullopt;
+  }
+
+  // Phase 1: latency delay
+  const double t1 = std::max(0.0, initial_time_delay);
+  const auto [x1, v1, a1] = update(0.0, v0, a0, 0.0, t1);
+
+  // If the vehicle naturally stops during the delay phase due to existing deceleration
+  if (v1 <= 0.0 && (a0 <= -epsilon || a0 >= epsilon)) {
+    const double t_stop = -v0 / a0;
+    const auto [x_stop, v_stop, a_stop] = update(0.0, v0, a0, 0.0, t_stop);
+    return std::max(0.0, x_stop);
+  }
+
+  // Phase 2: jerk-limited braking
+  // Calculate what the velocity (v2) would be exactly when the acceleration reaches acc_limit
+  const double v2 =
+    v1 + (negative_decel_limit * negative_decel_limit - a1 * a1) / (2.0 * negative_jerk_limit);
+
+  if (v2 <= 0.0) {
+    // The vehicle reaches v = 0 before hitting the maximum deceleration limit.
+    // Solve for t where 0 = v1 + a1*t + 0.5*j*t^2
+    const double discriminant = a1 * a1 - 2.0 * jerk_limit * v1;
+
+    // should be impossible
+    if (discriminant < 0.0) {
+      return std::nullopt;
+    }
+
+    const double t2 = -(a1 + std::sqrt(discriminant)) / jerk_limit;
+    const auto [x_stop, v_stop, a_stop] = update(x1, v1, a1, jerk_limit, t2);
+
+    return std::max(0.0, x_stop);
+  }
+
+  // The vehicle successfully reaches the maximum deceleration limit.
+  const double t2 = (negative_decel_limit - a1) / jerk_limit;
+  const auto [x2, v2_final, a2_final] = update(x1, v1, a1, jerk_limit, t2);
+
+  // Phase 3: Constant maximum deceleration
+  // Decelerate at acc_limit from v2_final down to 0.
+  const double x3 = -(v2_final * v2_final) / (2.0 * negative_decel_limit);
+
+  return std::max(0.0, x2 + x3);
+}
+
 }  // namespace autoware::motion_utils

--- a/common/autoware_motion_utils/test/src/distance/test_distance.cpp
+++ b/common/autoware_motion_utils/test/src/distance/test_distance.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2023-2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 namespace
 {
 using autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints;
+using autoware::motion_utils::calculate_stop_distance;
 
 constexpr double epsilon = 1e-3;
 
@@ -141,6 +142,76 @@ TEST(distance, calcDecelDistWithJerkAndAccConstraints)
       current_vel, target_vel, current_acc, acc_min, jerk_acc, jerk_dec);
     EXPECT_NEAR(expected_dist, *dist, epsilon);
   }
+}
+
+TEST(CalculateStopDistanceTest, ReturnsZeroWhenAlreadyStopped)
+{
+  auto result = calculate_stop_distance(0.0, 0.0, -4.0, -10.0, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalculateStopDistanceTest, ReturnsZeroWhenReversing)
+{
+  auto result = calculate_stop_distance(-2.5, 0.0, -4.0, -10.0, 1.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalculateStopDistanceTest, FailsOnInvalidKinematicLimits)
+{
+  // Zero limits (would cause division by zero)
+  EXPECT_FALSE(calculate_stop_distance(10.0, 0.0, 0.0, -10.0).has_value());
+  EXPECT_FALSE(calculate_stop_distance(10.0, 0.0, -4.0, 0.0).has_value());
+}
+
+TEST(CalculateStopDistanceTest, Phase1Stop_StopsDuringDelayPhase)
+{
+  // v0 = 2.0 m/s, a0 = -2.0 m/s^2. Delay = 2.0s.
+  // Vehicle will naturally stop at t = 1.0s, completely within the delay phase.
+  // Distance = v0*t + 0.5*a0*t^2 = 2.0(1) + 0.5(-2)(1) = 1.0 m.
+  auto result = calculate_stop_distance(2.0, -2.0, -5.0, -2.0, 2.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 1.0, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, Phase2Stop_StopsDuringJerkPhase)
+{
+  // v0 = 1.0 m/s, a0 = 0.0. No delay. Limits: a = -5.0, j = -2.0.
+  // Vehicle stops before reaching max decel (-5.0).
+  // Solves to t = 1.0s. Distance = 1.0(1) + 1/6(-2)(1^3) = 1 - 0.3333 = 0.6666... m.
+  auto result = calculate_stop_distance(1.0, 0.0, -5.0, -2.0, 0.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 2.0 / 3.0, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, Phase3Stop_StandardThreePhaseStop)
+{
+  // Standard high-speed stop.
+  // v0 = 10.0, a0 = 0.0. Delay = 1.0s. Limits: a = -2.0, j = -2.0.
+  // Phase 1 (Delay): t = 1.0s, x1 = 10.0m, v1 = 10.0m/s.
+  // Phase 2 (Jerk) : t = 1.0s to reach a=-2.0. x2 = 9.6666m, v2 = 9.0m/s.
+  // Phase 3 (Decel): from v2=9.0 down to 0 at a=-2.0. x3 = 20.25m.
+  // Total Expected: 10.0 + 9.6666... + 20.25 = 39.91666... m.
+  auto result = calculate_stop_distance(10.0, 0.0, -2.0, -2.0, 1.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 39.9166, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, HandlesAlreadyExceedingDecelerationLimit)
+{
+  // If the vehicle is braking at -6.0m/s² acceleration but the limit is -4.0m/s²,
+  // the function uses a limit of -6.0 to maintain valid math.
+  // v0 = 10.0, a0 = -6.0, a_limit = -4.0 (increased to -6.0). No delay.
+  // Phase 2 is skipped (already at limit).
+  // Phase 3: x = -v0^2 / (2*a_limit) = -100 / (2 * -6) = 8.333
+  auto result = calculate_stop_distance(10.0, -6.0, -4.0, -10.0, 0.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 8.3333, epsilon);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Cherry pick https://github.com/autowarefoundation/autoware_core/pull/849 for adding a common function to calculate the required distance to stop under jerk and acceleration constraints

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
