### PR TITLE
feat(motion_utils): add option to pose interpolation (#997)

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/interpolation.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/interpolation.hpp
@@ -63,7 +63,9 @@ autoware_internal_planning_msgs::msg::PathPointWithLaneId calcInterpolatedPoint(
  * @return resampled pose
  */
 template <class T>
-geometry_msgs::msg::Pose calcInterpolatedPose(const T & points, const double target_length)
+geometry_msgs::msg::Pose calcInterpolatedPose(
+  const T & points, const double target_length,
+  const bool set_orientation_from_position_direction = true)
 {
   if (points.empty()) {
     geometry_msgs::msg::Pose interpolated_pose;
@@ -81,7 +83,8 @@ geometry_msgs::msg::Pose calcInterpolatedPose(const T & points, const double tar
     const double length = autoware_utils_geometry::calc_distance3d(curr_pose, next_pose);
     if (accumulated_length + length > target_length) {
       const double ratio = (target_length - accumulated_length) / std::max(length, 1e-6);
-      return autoware_utils_geometry::calc_interpolated_pose(curr_pose, next_pose, ratio);
+      return autoware_utils_geometry::calc_interpolated_pose(
+        curr_pose, next_pose, ratio, set_orientation_from_position_direction);
     }
     accumulated_length += length;
   }


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware_core/pull/997 のcherry-pickです

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
