### PR TITLE
fix(autoware_agnocast_wrapper): refer to ROS_DISTRO for heaphook_path…

### DIFF
--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -17,13 +17,15 @@
 Configuration:
 - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
 - Heaphook path is configurable via the agnocast_heaphook_path arg
-  (default: /opt/ros/humble/lib/libagnocast_heaphook.so)
+  (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
 Provides the following launch configurations:
 - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
 - container_package: resolved component container package name
 - container_executable: resolved component container executable name
 """
+
+import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -68,7 +70,7 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "agnocast_heaphook_path",
-                default_value="/opt/ros/humble/lib/libagnocast_heaphook.so",
+                default_value=f"/opt/ros/{os.environ.get('ROS_DISTRO', 'humble')}/lib/libagnocast_heaphook.so",
             ),
             DeclareLaunchArgument(
                 "use_multithread",

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -4,7 +4,7 @@
     Configuration:
     - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
     - Heaphook path is configurable via the agnocast_heaphook_path arg
-      (default: /opt/ros/humble/lib/libagnocast_heaphook.so)
+      (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
     Provides the following variables:
     - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
@@ -12,7 +12,7 @@
     - container_executable: resolved component container executable name
   -->
 
-  <arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so"/>
+  <arg name="agnocast_heaphook_path" default="/opt/ros/$(env ROS_DISTRO humble)/lib/libagnocast_heaphook.so"/>
   <arg name="use_multithread" default="false"/>
   <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
 


### PR DESCRIPTION
## Description
Agnocastのros2 jazzy対応の一環。
Cherry-pick https://github.com/autowarefoundation/autoware_core/pull/1037.

agnocastを適用したノードのlaunchでincludeされる以下の２つのファイルについて、`/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` をデフォルトで参照するように変更
(変更前は`/opt/ros/humble/lib/libagnocast_heaphook.so` )。

- agnocast_env.launch.xml: default agnocast_heaphook_path now uses $(env ROS_DISTRO humble).
- agnocast_env.launch.py: default uses os.environ.get('ROS_DISTRO', 'humble').

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
