### PR TITLE
chore: cherry pick agnocast wrapper PRs

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -106,4 +106,11 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_discovery_agent_launch
+    test/test_discovery_agent_launch.py
+  )
+endif()
+
 autoware_ament_auto_package()

--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(rclcpp REQUIRED)
 find_package(autoware_utils_rclcpp REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(glog REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(agnocastlib REQUIRED)
@@ -31,6 +34,9 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     autoware_utils_rclcpp
     message_filters
     glog
+    geometry_msgs
+    tf2
+    tf2_ros
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -39,6 +45,9 @@ else()
     autoware_utils_rclcpp
     message_filters
     glog
+    geometry_msgs
+    tf2
+    tf2_ros
   )
 endif()
 
@@ -49,10 +58,13 @@ ament_export_include_directories(
 ament_export_dependencies(
   autoware_utils_rclcpp
   class_loader
+  geometry_msgs
   message_filters
   rclcpp
   rclcpp_components
   glog
+  tf2
+  tf2_ros
 )
 
 ament_export_libraries(

--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(rclcpp REQUIRED)
 find_package(autoware_utils_rclcpp REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(glog REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -34,6 +35,7 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     autoware_utils_rclcpp
     message_filters
     glog
+    diagnostic_updater
     geometry_msgs
     tf2
     tf2_ros
@@ -45,6 +47,7 @@ else()
     autoware_utils_rclcpp
     message_filters
     glog
+    diagnostic_updater
     geometry_msgs
     tf2
     tf2_ros
@@ -63,6 +66,7 @@ ament_export_dependencies(
   rclcpp
   rclcpp_components
   glog
+  diagnostic_updater
   tf2
   tf2_ros
 )

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -36,16 +36,17 @@ public:
   {
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
-      "input", 10, [this](std::unique_ptr<const std_msgs::msg::String> msg) { /* ... */ });
+      "input", 10,
+      [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) && msg) { /* ... */ });
 
     timer_ = create_wall_timer(
       std::chrono::milliseconds(100), [this]() { /* ... */ });
   }
 
 private:
-  autoware::agnocast_wrapper::Publisher<std_msgs::msg::String>::SharedPtr pub_;
-  autoware::agnocast_wrapper::Subscription<std_msgs::msg::String>::SharedPtr sub_;
-  autoware::agnocast_wrapper::Timer::SharedPtr timer_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::String) pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(std_msgs::msg::String) sub_;
+  AUTOWARE_TIMER_PTR timer_;
 };
 ```
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -231,6 +231,52 @@ void onSynchronized(
 | `message_filters::Synchronizer<Policy>`                   | `autoware::agnocast_wrapper::message_filters::Synchronizer<Policy>`                   |
 | `message_filters::sync_policies::ApproximateTime<M0, M1>` | `autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<M0, M1>` |
 
+## tf2 Support
+
+This package provides wrapper types for tf2 (`TransformListener`, `TransformBroadcaster`, `StaticTransformBroadcaster`, `Buffer`) in the `autoware::agnocast_wrapper` namespace. The listener and broadcasters transparently switch between their `tf2_ros` and `agnocast` implementations at runtime, depending on whether the given node is running in Agnocast mode.
+
+The node-taking constructors require a Method 2 node (`autoware::agnocast_wrapper::Node`). This is needed because an AgnocastOnly executor does not spin a plain `tf2_ros::TransformListener` (a ROS 2 subscription); routing `/tf` through Agnocast keeps tf callbacks firing.
+
+`Buffer` aliases to `agnocast::Buffer` in Agnocast-enabled builds and `tf2_ros::Buffer` otherwise. The agnocast variant intentionally omits APIs that would silently break under an AgnocastOnly executor (currently `waitForTransform` / `setCreateTimerInterface` and the `/tf2_frames` debug service), so misuse is caught at compile time.
+
+### Usage example
+
+```cpp
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
+
+class MyNode : public autoware::agnocast_wrapper::Node
+{
+public:
+  MyNode()
+  : autoware::agnocast_wrapper::Node("my_node"), tf_buffer_(this->get_clock())
+  {
+    // `*this` is a node derived from autoware::agnocast_wrapper::Node.
+    tf_listener_ = std::make_unique<autoware::agnocast_wrapper::TransformListener>(
+      tf_buffer_, *this);
+    tf_broadcaster_ = std::make_unique<autoware::agnocast_wrapper::TransformBroadcaster>(*this);
+  }
+
+private:
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  std::unique_ptr<autoware::agnocast_wrapper::TransformListener> tf_listener_;
+  std::unique_ptr<autoware::agnocast_wrapper::TransformBroadcaster> tf_broadcaster_;
+};
+```
+
+### Migration guide (from `tf2_ros`)
+
+| Before                                                | After                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| `#include <tf2_ros/transform_listener.hpp>`           | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/buffer.hpp>`                       | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/transform_broadcaster.hpp>`        | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/static_transform_broadcaster.hpp>` | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `tf2_ros::TransformListener`                          | `autoware::agnocast_wrapper::TransformListener`          |
+| `tf2_ros::Buffer`                                     | `autoware::agnocast_wrapper::Buffer`                     |
+| `tf2_ros::TransformBroadcaster`                       | `autoware::agnocast_wrapper::TransformBroadcaster`       |
+| `tf2_ros::StaticTransformBroadcaster`                 | `autoware::agnocast_wrapper::StaticTransformBroadcaster` |
+
 ## How to Enable/Disable Agnocast on Build
 
 To build Autoware **with** Agnocast:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -183,11 +183,11 @@ autoware_agnocast_wrapper_setup(target)
 
 ## Message Filters Support
 
-This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
+This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`, `ExactTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
 
 ### Current limitations
 
-- Only `ApproximateTime` synchronization policy is supported (no `ExactTime`).
+- Only `ApproximateTime` and `ExactTime` synchronization policies are supported.
 - Maximum 2 message types per `Synchronizer`.
 - `connectInput()` is not supported; pass `Subscriber` references at construction time.
 
@@ -230,6 +230,7 @@ void onSynchronized(
 | `message_filters::Subscriber<M>`                          | `autoware::agnocast_wrapper::message_filters::Subscriber<M>`                          |
 | `message_filters::Synchronizer<Policy>`                   | `autoware::agnocast_wrapper::message_filters::Synchronizer<Policy>`                   |
 | `message_filters::sync_policies::ApproximateTime<M0, M1>` | `autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<M0, M1>` |
+| `message_filters::sync_policies::ExactTime<M0, M1>`       | `autoware::agnocast_wrapper::message_filters::sync_policies::ExactTime<M0, M1>`       |
 
 ## tf2 Support
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -296,6 +296,53 @@ private:
 | `tf2_ros::TransformBroadcaster`                       | `autoware::agnocast_wrapper::TransformBroadcaster`       |
 | `tf2_ros::StaticTransformBroadcaster`                 | `autoware::agnocast_wrapper::StaticTransformBroadcaster` |
 
+## Diagnostic Updater Support
+
+This package provides a wrapper `autoware::agnocast_wrapper::diagnostic_updater::Updater` for `diagnostic_updater::Updater`. The wrapper transparently switches between `diagnostic_updater::Updater` and `agnocast::Updater` at runtime, so nodes inheriting from `autoware::agnocast_wrapper::Node` can use the same idiom in both modes.
+
+The `diagnostic_updater.period` and `diagnostic_updater.use_fqn` parameters are declared identically in both modes, so behavior remains consistent.
+
+### Current limitations
+
+- Only the `Updater(autoware::agnocast_wrapper::Node*, double)` constructor is supported. The upstream interface-pointer constructor and `Updater(NodeT, double)` template overload are intentionally hidden in both modes, so source code stays portable between agnocast-enabled and disabled builds.
+- The wrapper does **not** inherit from `DiagnosticTaskVector`, so `getTasks()` is not available.
+- The wrapper is non-copyable and non-movable; `verbose_` is bound by reference to the underlying impl.
+
+### Usage example
+
+```cpp
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+
+class MyNode : public autoware::agnocast_wrapper::Node
+{
+public:
+  explicit MyNode(const rclcpp::NodeOptions & options)
+  : Node("my_node", options), updater_(this)
+  {
+    updater_.setHardwareID("my_hardware");
+    updater_.add("status", this, &MyNode::diagnose);
+  }
+
+private:
+  void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "running");
+  }
+
+  autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
+};
+```
+
+### Migration guide (from `diagnostic_updater::Updater`)
+
+| Before                                                 | After                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `#include <diagnostic_updater/diagnostic_updater.hpp>` | `#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>`             |
+| `diagnostic_updater::Updater updater_{this};`          | `autoware::agnocast_wrapper::diagnostic_updater::Updater updater_{this};` |
+
+The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broadcast()` / `force_update()` / `setPeriod()` / `getPeriod()` APIs and the `verbose_` field behave the same as the upstream `diagnostic_updater::Updater`.
+
+> **Note:** `DiagnosticTask` subclasses (e.g. `FrequencyStatus`, `TimeStampStatus`, `Heartbeat`) defined in `diagnostic_updater` can be added via `updater_.add(task)` unchanged.
+
 ## How to Enable/Disable Agnocast on Build
 
 To build Autoware **with** Agnocast:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -201,7 +201,7 @@ autoware_agnocast_wrapper_setup(target)
 
 ## Message Filters Support
 
-This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`, `ExactTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
+This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
 
 ### Current limitations
 
@@ -227,9 +227,17 @@ using Policy = sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
 Synchronizer<Policy> sync(Policy(10), image_sub, info_sub);
 
-// 3. Register callback (use std::bind, not a lambda — see migration note below)
-sync.registerCallback(
-  std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+// 3. Register callback. Mirrors `::message_filters::Synchronizer::registerCallback` —
+//    pass a member-function pointer and `this`, or a `std::bind` result, or any other
+//    callable convertible to `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
+//                                    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
+//    Returns a `::message_filters::Connection` for later `.disconnect()`.
+auto conn = sync.registerCallback(&MyNode::onSynchronized, this);
+// Note: `conn` going out of scope does NOT unregister the callback.
+// Call conn.disconnect() explicitly if you need to remove it later.
+// Equivalent form (still supported):
+// sync.registerCallback(std::bind(
+//   &MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
 ```
 
 The callback method signature should use `const` references:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -19,12 +19,11 @@ Use this when you want the **entire node** to transparently switch between `rclc
 Currently supported APIs:
 
 - Publisher / Subscription / PollingSubscriber
+- Timer (`create_wall_timer`, free `create_timer()`, free `set_period()`)
 - Parameters
 - Logger, Clock
 - Callback groups
 - Node interfaces (partial: `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()`)
-
-> **Note:** Timer (`create_wall_timer`, `create_timer`) is not yet supported and will be added in a future update.
 
 ```cpp
 #include <autoware/agnocast_wrapper/node.hpp>
@@ -38,12 +37,31 @@ public:
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
       "input", 10, [this](std::unique_ptr<const std_msgs::msg::String> msg) { /* ... */ });
+
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(100), [this]() { /* ... */ });
   }
 
 private:
   autoware::agnocast_wrapper::Publisher<std_msgs::msg::String>::SharedPtr pub_;
   autoware::agnocast_wrapper::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  autoware::agnocast_wrapper::Timer::SharedPtr timer_;
 };
+```
+
+#### Timer notes
+
+`create_timer()` is provided as a **free function** (not a member) because `rclcpp::Node::create_timer` was added in Jazzy and does not exist on Humble. The free form is portable across both:
+
+```cpp
+timer_ = autoware::agnocast_wrapper::create_timer(
+  this, this->get_clock(), rclcpp::Duration::from_seconds(0.1), [this]() { /* ... */ });
+```
+
+`set_period()` is likewise a **free function**. `rclcpp::TimerBase` has no `set_period` member, so the free form is the only portable spelling across both builds:
+
+```cpp
+autoware::agnocast_wrapper::set_period(timer_, std::chrono::milliseconds(200));
 ```
 
 To use the Node wrapper in your package, add the following to your `CMakeLists.txt`:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -420,10 +420,11 @@ After including `agnocast_env.launch.xml` (or `agnocast_env.launch.py`), the fol
 
 ### Launch Arguments
 
-| Argument                 | Default                                       | Description                                                           |
-| ------------------------ | --------------------------------------------- | --------------------------------------------------------------------- |
-| `agnocast_heaphook_path` | `/opt/ros/humble/lib/libagnocast_heaphook.so` | Path to the heaphook shared library                                   |
-| `use_multithread`        | `false`                                       | Use the multi-threaded component container (`component_container_mt`) |
+| Argument                 | Default                                                                     | Description                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` (falls back to `humble`) | Path to the heaphook shared library                                                                     |
+| `use_multithread`        | `false`                                                                     | Use the multi-threaded component container (`component_container_mt`)                                   |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                                                  | Per-node override (`1`/`0`). Usually left unset; defaults to the `ENABLE_AGNOCAST` environment variable |
 
 The `container_executable` is resolved as follows:
 
@@ -456,9 +457,23 @@ Using a component container with multi-threading:
 </node_container>
 ```
 
+Disabling Agnocast for a single include (debugging / emergency fallback):
+
+```xml
+<include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml">
+  <arg name="use_agnocast" value="0"/>
+</include>
+
+<node pkg="my_package" exec="my_node" name="my_node">
+  <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+</node>
+```
+
+Even when the workspace is built with `ENABLE_AGNOCAST=1`, passing `use_agnocast` to a single include forces that node (or container) back to the plain `rclcpp` path without touching the rest of the launch tree. Use it to temporarily disable Agnocast for one node while debugging, or as an emergency fallback when a specific node misbehaves under Agnocast.
+
 ### Examples (Python)
 
-A Python launch file (`agnocast_env.launch.py`) is also provided with the same functionality. It sets the same launch configurations (`ld_preload_value`, `container_package`, `container_executable`) that can be referenced via `LaunchConfiguration`.
+A Python launch file (`agnocast_env.launch.py`) is also provided with the same functionality. It accepts the same `use_agnocast` argument and sets the same launch configurations (`ld_preload_value`, `container_package`, `container_executable`) that can be referenced via `LaunchConfiguration`.
 
 Basic usage with a single node:
 
@@ -528,5 +543,7 @@ def generate_launch_description():
 
     return LaunchDescription([agnocast_env, container])
 ```
+
+The same `use_agnocast` override works here too, via `launch_arguments={"use_agnocast": "0"}.items()`.
 
 This ensures that only the intended nodes receive the heaphook, rather than all nodes in the launch tree.

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -299,11 +299,15 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Base class has been changed to `autoware::agnocast_wrapper::Node`
 
-- [ ] Member variable types: `AUTOWARE_*_PTR` macros or `autoware::agnocast_wrapper::Publisher<M>::SharedPtr` etc.
+- [ ] Member variable types: `AUTOWARE_*_PTR` macros (e.g. `AUTOWARE_PUBLISHER_PTR(M)`)
 
 - [ ] Creation: Use `agnocast_wrapper::Node` member functions `create_publisher` / `create_subscription` directly (**`AUTOWARE_CREATE_*` macros are not needed**)
 
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR`
+
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
+
+- [ ] If the node also uses message_filters, timers, tf2, or diagnostic_updater, they have been migrated to the corresponding `autoware::agnocast_wrapper::*` wrappers (see the [README](../README.md) for usage and current limitations)
 
 - [ ] If the original CMakeLists.txt used `rclcpp_components_register_node()`, it has been replaced with `autoware_agnocast_wrapper_register_node()` (see Part 2 Section 5)
 
@@ -389,11 +393,11 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 
 ### Message Pointer Types
 
-| Macro                                     | ENABLE_AGNOCAST=1 (Agnocast) | ENABLE_AGNOCAST=0 (ROS 2)     |
-| ----------------------------------------- | ---------------------------- | ----------------------------- |
-| `AUTOWARE_MESSAGE_UNIQUE_PTR(MsgT)`       | `message_ptr<MsgT, Unique>`  | `std::unique_ptr<MsgT>`       |
-| `AUTOWARE_MESSAGE_SHARED_PTR(MsgT)`       | `message_ptr<MsgT, Shared>`  | `std::shared_ptr<MsgT>`       |
-| `AUTOWARE_MESSAGE_CONST_SHARED_PTR(MsgT)` | `message_ptr<MsgT, Shared>`  | `std::shared_ptr<const MsgT>` |
+| Macro                                     | ENABLE_AGNOCAST=1 (Agnocast)      | ENABLE_AGNOCAST=0 (ROS 2)     |
+| ----------------------------------------- | --------------------------------- | ----------------------------- |
+| `AUTOWARE_MESSAGE_UNIQUE_PTR(MsgT)`       | `message_ptr<MsgT, Unique>`       | `std::unique_ptr<MsgT>`       |
+| `AUTOWARE_MESSAGE_SHARED_PTR(MsgT)`       | `message_ptr<MsgT, Shared>`       | `std::shared_ptr<MsgT>`       |
+| `AUTOWARE_MESSAGE_CONST_SHARED_PTR(MsgT)` | `message_ptr<const MsgT, Shared>` | `std::shared_ptr<const MsgT>` |
 
 > `AUTOWARE_MESSAGE_SHARED_PTR` is for publishers (mutable messages), while `AUTOWARE_MESSAGE_CONST_SHARED_PTR` is for subscriptions (read-only messages).
 
@@ -496,12 +500,13 @@ public:
   {
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
-      "input", 10, [this](auto msg) { /* ... */ });
+      "input", 10,
+      [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(std_msgs::msg::String) && msg) { /* ... */ });
   }
 
 private:
-  autoware::agnocast_wrapper::Publisher<std_msgs::msg::String>::SharedPtr pub_;
-  autoware::agnocast_wrapper::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::String) pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(std_msgs::msg::String) sub_;
 };
 ```
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -22,9 +22,14 @@
 #include "autoware_utils_rclcpp/polling_subscriber.hpp"
 
 #include <agnocast/agnocast.hpp>
+#include <rclcpp/exceptions/exceptions.hpp>
 
+#include <rcl/timer.h>
+
+#include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) \
@@ -44,6 +49,7 @@
   typename autoware::agnocast_wrapper::Publisher<MessageT>::SharedPtr
 #define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
   typename autoware::agnocast_wrapper::PollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_TIMER_PTR autoware::agnocast_wrapper::Timer::SharedPtr
 
 #define AUTOWARE_CREATE_SUBSCRIPTION(message_type, topic, qos, callback, options) \
   autoware::agnocast_wrapper::create_subscription<message_type>(this, topic, qos, callback, options)
@@ -592,16 +598,159 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   }
 }
 
+/// @brief Type-erased timer handle for the Agnocast build.
+///
+/// Backed by AgnocastTimer or ROS2Timer depending on whether Agnocast is
+/// active at runtime. Must be obtained via Node::create_wall_timer() or the
+/// free create_timer() — do not construct directly. set_period() is
+/// intentionally private; use the free set_period(Timer::SharedPtr, ...)
+/// instead, which is also available in non-Agnocast builds.
+///
+/// Cross-build portability: in non-Agnocast builds AUTOWARE_TIMER_PTR
+/// resolves to rclcpp::TimerBase::SharedPtr and exposes the full rclcpp API;
+/// in Agnocast builds it resolves to this wrapper, which only exposes
+/// cancel/reset/is_canceled/time_until_trigger and the free set_period().
+/// Calling any other rclcpp::TimerBase method compiles in non-Agnocast builds
+/// but breaks once Agnocast is enabled. Stay within the wrapper's surface to
+/// remain portable.
+///
+/// Exception contract: the exception type and "throw vs no-op" behavior of
+/// these methods is not normalized across backends — the rclcpp backend tends
+/// to throw rclcpp::exceptions::RCLError on rcl failure, while the Agnocast
+/// backend may throw std::runtime_error or silently return a sentinel. This
+/// asymmetry exists across the wrapper as a whole (not Timer-specific) and is
+/// expected to be normalized in a follow-up.
+class Timer
+{
+public:
+  using SharedPtr = std::shared_ptr<Timer>;
+  virtual ~Timer() = default;
+
+  virtual void cancel() = 0;
+  virtual void reset() = 0;
+  virtual bool is_canceled() = 0;
+  virtual std::chrono::nanoseconds time_until_trigger() = 0;
+
+private:
+  // Private so callers must use the free set_period() function, which also works in the
+  // non-agnocast build (where AUTOWARE_TIMER_PTR is a plain rclcpp::TimerBase, no set_period).
+  virtual void set_period(std::chrono::nanoseconds period) = 0;
+  friend void set_period(const SharedPtr & timer, std::chrono::nanoseconds period);
+};
+
+class AgnocastTimer : public Timer
+{
+  std::shared_ptr<agnocast::TimerBase> timer_;
+
+public:
+  explicit AgnocastTimer(std::shared_ptr<agnocast::TimerBase> timer) : timer_(std::move(timer)) {}
+
+  void cancel() override { timer_->cancel(); }
+  void reset() override { timer_->reset(); }
+  bool is_canceled() override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() override { return timer_->time_until_trigger(); }
+
+private:
+  void set_period(std::chrono::nanoseconds period) override { timer_->set_period(period); }
+};
+
+class ROS2Timer : public Timer
+{
+  rclcpp::TimerBase::SharedPtr timer_;
+
+public:
+  explicit ROS2Timer(rclcpp::TimerBase::SharedPtr timer) : timer_(std::move(timer)) {}
+
+  void cancel() override { timer_->cancel(); }
+  void reset() override { timer_->reset(); }
+  bool is_canceled() override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() override { return timer_->time_until_trigger(); }
+
+private:
+  // rclcpp::TimerBase does not expose a set_period API; fall back to the rcl C API and
+  // convert the rcl_ret_t to an rclcpp::exceptions::RCLError (matching the throw style used
+  // by the other rclcpp timer methods such as cancel/reset/time_until_trigger).
+  void set_period(std::chrono::nanoseconds period) override
+  {
+    int64_t old_period = 0;
+    const rcl_ret_t ret =
+      rcl_timer_exchange_period(timer_->get_timer_handle().get(), period.count(), &old_period);
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
+    }
+  }
+};
+
+/// @brief Set the timer period.
+///
+/// Provided as a free function so the same call site compiles in both builds:
+/// in non-Agnocast builds rclcpp::TimerBase has no set_period member, so a
+/// free overload is the only portable form. Timer::set_period is private to
+/// prevent member-style calls that would not survive the non-Agnocast build.
+///
+/// @throws std::invalid_argument if period is negative or equal to
+///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
+///   precondition 0 <= period < nanoseconds::max()).
+/// @throws rclcpp::exceptions::RCLError on rcl-level failure when the ROS 2
+///   backend is active (see Timer's class-level note on exception asymmetry
+///   between backends).
+inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
+{
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
+  timer->set_period(period);
+}
+
 }  // namespace autoware::agnocast_wrapper
 
 #else
 
 #include "autoware_utils_rclcpp/polling_subscriber.hpp"
 
+#include <rclcpp/exceptions/exceptions.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <rcl/timer.h>
+
+#include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
+
+namespace autoware::agnocast_wrapper
+{
+
+/// @brief Set the timer period (non-Agnocast build).
+///
+/// rclcpp::TimerBase has no set_period member, so we provide a free overload
+/// that falls back to the rcl C API. Mirrors the Agnocast-build overload on
+/// Timer::SharedPtr so the same call site works in both builds.
+///
+/// @throws std::invalid_argument if period is negative or equal to
+///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
+///   precondition 0 <= period < nanoseconds::max()).
+/// @throws rclcpp::exceptions::RCLError on rcl-level failure.
+inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
+{
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
+  int64_t old_period = 0;
+  const rcl_ret_t ret =
+    rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
+  }
+}
+
+}  // namespace autoware::agnocast_wrapper
 
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) std::unique_ptr<MessageT>
 // For publisher (mutable message)
@@ -612,6 +761,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename rclcpp::Publisher<MessageT>::SharedPtr
 #define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_TIMER_PTR rclcpp::TimerBase::SharedPtr
 
 #define AUTOWARE_CREATE_SUBSCRIPTION(message_type, topic, qos, callback, options) \
   this->create_subscription<message_type>(topic, qos, callback, options)

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -1,0 +1,306 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cspell:ignore hwid
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+
+#include <diagnostic_updater/diagnostic_updater.hpp>
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <variant>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
+
+namespace autoware::agnocast_wrapper
+{
+namespace diagnostic_updater
+{
+
+/// @brief Wrapper Updater that dispatches between ::diagnostic_updater::Updater
+///        (rclcpp mode) and ::agnocast::Updater (agnocast mode) at runtime,
+///        depending on whether the given autoware::agnocast_wrapper::Node is
+///        running in agnocast mode.
+///
+/// Constructor signature mirrors `::diagnostic_updater::Updater updater_{this};`
+/// so nodes inheriting from autoware::agnocast_wrapper::Node can use the same
+/// idiom in both modes. The `diagnostic_updater.period` and
+/// `diagnostic_updater.use_fqn` ros2 parameters are declared by the underlying
+/// impl identically in both backends, so observed behavior is consistent.
+///
+/// @invariant The backend variant is selected from use_agnocast() at construction
+///            and never changes. impl_ holds the active backend through unique_ptr,
+///            so the underlying impl object's address stays stable for the
+///            wrapper's lifetime — `verbose_` is bound by reference to that
+///            stable address.
+///
+/// @code
+/// #include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+///
+/// class MyNode : public autoware::agnocast_wrapper::Node
+/// {
+/// public:
+///   explicit MyNode(const rclcpp::NodeOptions & options)
+///   : Node("my_node", options), updater_(this)
+///   {
+///     updater_.setHardwareID("my_hardware");
+///     updater_.add("status", this, &MyNode::diagnose);
+///   }
+///
+/// private:
+///   void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat) {
+///     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "running");
+///   }
+///
+///   autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
+/// };
+/// @endcode
+class Updater
+{
+public:
+  /// @brief Heap-allocated rclcpp-backed implementation held inside impl_.
+  using RclcppImpl = std::unique_ptr<::diagnostic_updater::Updater>;
+
+  /// @brief Heap-allocated agnocast-backed implementation held inside impl_.
+  using AgnocastImpl = std::unique_ptr<::agnocast::Updater>;
+
+  /// @brief Construct an Updater bound to a wrapper Node.
+  ///
+  /// Selects the backend from use_agnocast() at construction; the choice is
+  /// fixed for the wrapper's lifetime.
+  ///
+  /// @pre The given Node must outlive this Updater. ::agnocast::Updater stores
+  ///      `agnocast::Node &` by reference (initialized from
+  ///      `*node->get_agnocast_node()`), and ::diagnostic_updater::Updater holds
+  ///      interface pointers extracted from the rclcpp::Node. Outliving the
+  ///      wrapper Node will dangle in both modes.
+  ///
+  /// @param node   Wrapper node providing access to either an agnocast::Node or
+  ///               an rclcpp::Node.
+  /// @param period Default update period in seconds; overridden by the
+  ///               `diagnostic_updater.period` ros2 parameter if set.
+  ///
+  /// @note The upstream `::diagnostic_updater::Updater` exposes a third
+  ///       `starting_up_status` parameter (the DiagnosticStatus level sent as
+  ///       the first message). It is intentionally not surfaced here because
+  ///       `::agnocast::Updater` does not support it, and the wrapper keeps a
+  ///       single signature shared by both backends.
+  explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
+  : logger_(node->get_logger()),
+    impl_(
+      // unique_ptr indirection is required because both ::diagnostic_updater::Updater
+      // and ::agnocast::Updater are non-movable (their constructors register internal
+      // callbacks that capture `this`). std::variant alternatives must be at least
+      // move-constructible, so we hold each impl through unique_ptr to satisfy that
+      // constraint while keeping the underlying impl's address stable.
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<::agnocast::Updater>(*node->get_agnocast_node(), period))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>,
+            std::make_unique<::diagnostic_updater::Updater>(node->get_rclcpp_node(), period))),
+    verbose_(std::visit([](auto & impl) -> bool & { return impl->verbose_; }, impl_))
+  {
+  }
+
+  /// @brief Register a diagnostic task by name and callable.
+  ///
+  /// Dispatches to ::diagnostic_updater::Updater::add() or ::agnocast::Updater::add()
+  /// depending on the active backend.
+  ///
+  /// @param name Diagnostic task name surfaced in the published DiagnosticStatus.
+  /// @param f    Callable invoked each update cycle to fill in a DiagnosticStatusWrapper.
+  void add(const std::string & name, ::diagnostic_updater::TaskFunction f)
+  {
+    std::visit([&](auto & impl) { impl->add(name, f); }, impl_);
+  }
+
+  /// @brief Register a diagnostic task object by reference.
+  ///
+  /// The task is stored by reference inside the underlying Updater; the caller
+  /// must ensure the task outlives this Updater. Useful for adding pre-built
+  /// task types such as FrequencyStatus, TimeStampStatus, or Heartbeat.
+  ///
+  /// @param task DiagnosticTask subclass instance.
+  void add(::diagnostic_updater::DiagnosticTask & task)
+  {
+    std::visit([&](auto & impl) { impl->add(task); }, impl_);
+  }
+
+  /// @brief Register a diagnostic task by name and member function pointer.
+  ///
+  /// @tparam T   Class type owning the diagnostic method.
+  /// @param name Diagnostic task name.
+  /// @param c    Pointer to the owning instance; must outlive this Updater.
+  /// @param f    Member function called each update cycle.
+  template <class T>
+  void add(
+    const std::string name, T * c, void (T::*f)(::diagnostic_updater::DiagnosticStatusWrapper &))
+  {
+    std::visit([&](auto & impl) { impl->add(name, c, f); }, impl_);
+  }
+
+  /// @brief Remove a previously added task by name.
+  /// @param name Task name passed to a prior add() call.
+  /// @return true if a task with that name was found and removed; false otherwise.
+  bool removeByName(const std::string name)
+  {
+    return std::visit([&](auto & impl) { return impl->removeByName(name); }, impl_);
+  }
+
+  /// @brief Get the current update period as rclcpp::Duration.
+  auto getPeriod() const
+  {
+    return std::visit([](const auto & impl) { return impl->getPeriod(); }, impl_);
+  }
+
+  /// @brief Set the update period from rclcpp::Duration.
+  ///
+  /// Resets the internal timer to the new period.
+  void setPeriod(rclcpp::Duration period)
+  {
+    std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
+  }
+
+  /// @brief Set the update period in seconds.
+  ///
+  /// Convenience overload that converts to rclcpp::Duration internally.
+  void setPeriod(double period)
+  {
+    std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
+  }
+
+  /// @brief Force an immediate update of all known DiagnosticStatus tasks,
+  ///        bypassing the period interval.
+  ///
+  /// Useful when something drastic happens (shutdown, self-test) and the latest
+  /// status must be published immediately rather than waiting for the next tick.
+  void force_update()
+  {
+    std::visit([&](auto & impl) { impl->force_update(); }, impl_);
+  }
+
+  /// @brief Publish a single status with the given level and message across all
+  ///        known DiagnosticStatus tasks.
+  ///
+  /// @param lvl Diagnostic level
+  ///            (diagnostic_msgs::msg::DiagnosticStatus::OK / WARN / ERROR / STALE).
+  /// @param msg Status message attached to every task in the broadcast.
+  void broadcast(unsigned char lvl, const std::string msg)
+  {
+    std::visit([&](auto & impl) { impl->broadcast(lvl, msg); }, impl_);
+  }
+
+  /// @brief Set the hardware ID embedded in every published DiagnosticStatus.
+  /// @param hwid Hardware identifier string (free-form).
+  void setHardwareID(const std::string & hwid)
+  {
+    std::visit([&](auto & impl) { impl->setHardwareID(hwid); }, impl_);
+  }
+
+  /// @brief printf-style variant of setHardwareID, with truncation reported via
+  ///        RCLCPP_DEBUG when the formatted string overflows the internal buffer.
+  ///
+  /// We pre-format here (rather than forwarding the varargs to impl->setHardwareIDf)
+  /// so we can warn on truncation; C-style varargs (`...`) cannot be forwarded
+  /// cleanly across a std::visit boundary, and neither upstream impl exposes a
+  /// `vsetHardwareID(va_list)` overload. After formatting, storage is delegated to
+  /// setHardwareID -> impl, so the underlying hwid_ field stays in sync with the
+  /// active backend.
+  ///
+  /// @param format printf-style format string.
+  void setHardwareIDf(const char * format, ...)
+  {
+    va_list va;
+    constexpr int kBufferSize = 1000;
+    char buff[kBufferSize];
+    va_start(va, format);
+    if (vsnprintf(buff, kBufferSize, format, va) >= kBufferSize) {
+      RCLCPP_DEBUG(logger_, "Really long string in diagnostic_updater::setHardwareIDf.");
+    }
+    va_end(va);
+    setHardwareID(std::string(buff));
+  }
+
+  // Non-copyable and non-movable: `verbose_` is a reference bound at construction
+  // to impl_'s active alternative's `verbose_` field. References cannot be reseated,
+  // so neither copy-assign nor move (which would require rebinding) is meaningful.
+  Updater(const Updater &) = delete;
+  Updater & operator=(const Updater &) = delete;
+  Updater(Updater &&) = delete;
+  Updater & operator=(Updater &&) = delete;
+
+private:
+  rclcpp::Logger logger_;
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
+
+public:
+  /// Mirrors ::diagnostic_updater::Updater::verbose_ / ::agnocast::Updater::verbose_.
+  /// Bound by reference so `updater.verbose_ = true;` writes through to the
+  /// underlying impl, matching the field-access idiom of both upstream Updaters.
+  bool & verbose_;
+};
+
+}  // namespace diagnostic_updater
+}  // namespace autoware::agnocast_wrapper
+
+#else  // !USE_AGNOCAST_ENABLED
+
+namespace autoware::agnocast_wrapper
+{
+namespace diagnostic_updater
+{
+
+/// @brief Pass-through Updater for the non-Agnocast build.
+///
+/// Inherits from ::diagnostic_updater::Updater and re-declares only the
+/// `Updater(Node*, double)` constructor; base-class constructors are not
+/// implicitly inherited in C++, so the upstream template and interface-pointer
+/// constructors stay hidden. This keeps the supported signature identical to
+/// the agnocast-enabled build. All other public members are inherited as-is.
+class Updater : public ::diagnostic_updater::Updater
+{
+public:
+  /// @brief Construct from a wrapper Node and update period.
+  ///
+  /// In this build, autoware::agnocast_wrapper::Node is an alias for rclcpp::Node,
+  /// so the call forwards directly to ::diagnostic_updater::Updater(NodeT, double).
+  ///
+  /// @param node   Wrapper node (alias for rclcpp::Node in this build).
+  /// @param period Default update period in seconds; overridden by the
+  ///               `diagnostic_updater.period` ros2 parameter if set.
+  ///
+  /// @note The upstream `::diagnostic_updater::Updater` exposes a third
+  ///       `starting_up_status` parameter (the DiagnosticStatus level sent as
+  ///       the first message). It is intentionally not surfaced here because
+  ///       `::agnocast::Updater` does not support it, and the wrapper keeps a
+  ///       single signature shared by both backends.
+  explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
+  : ::diagnostic_updater::Updater(node, period)
+  {
+  }
+};
+
+}  // namespace diagnostic_updater
+}  // namespace autoware::agnocast_wrapper
+
+#endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp"
+#include "autoware/agnocast_wrapper/node.hpp"
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -45,30 +46,50 @@ public:
   Subscriber() = default;
 
   Subscriber(
-    rclcpp::Node * node, const std::string & topic,
+    autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     subscribe(node, topic, qos);
   }
 
+  /// @note The backend mode is captured here and reused by unsubscribe().
+  ///       The wrapper Node's backend mode is fixed at construction and does not
+  ///       change for the lifetime of the Node, so the captured value remains valid.
   void subscribe(
-    rclcpp::Node * node, const std::string & topic,
+    autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    if (use_agnocast()) {
-      agnocast_sub_.subscribe(node, topic, qos);
+    const bool tmp_agnocast = node->is_using_agnocast();
+    if (tmp_agnocast) {
+      agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
     } else {
-      rclcpp_sub_.subscribe(node, topic, qos);
+      rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
+    }
+    using_agnocast_ = tmp_agnocast;
+  }
+
+  /// @note Uses the backend mode captured during the preceding subscribe() call.
+  ///       Calling this before subscribe() is a harmless no-op.
+  void unsubscribe()
+  {
+    if (using_agnocast_) {
+      agnocast_sub_.unsubscribe();
+    } else {
+      rclcpp_sub_.unsubscribe();
     }
   }
 
   // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
-  ::message_filters::Subscriber<M> & rclcpp_subscriber() { return rclcpp_sub_; }
-  agnocast::message_filters::Subscriber<M> & agnocast_subscriber() { return agnocast_sub_; }
+  ::message_filters::Subscriber<M, rclcpp::Node> & rclcpp_subscriber() { return rclcpp_sub_; }
+  agnocast::message_filters::Subscriber<M, agnocast::Node> & agnocast_subscriber()
+  {
+    return agnocast_sub_;
+  }
 
 private:
-  ::message_filters::Subscriber<M> rclcpp_sub_;
-  agnocast::message_filters::Subscriber<M> agnocast_sub_;
+  bool using_agnocast_ = false;
+  ::message_filters::Subscriber<M, rclcpp::Node> rclcpp_sub_;
+  agnocast::message_filters::Subscriber<M, agnocast::Node> agnocast_sub_;
 };
 
 /// @brief Wrapper ApproximateTime Synchronizer that switches between

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -24,7 +24,9 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 
 #ifdef USE_AGNOCAST_ENABLED
 
@@ -39,57 +41,59 @@ namespace message_filters
 
 /// @brief Wrapper message_filters Subscriber that switches between
 ///        rclcpp and agnocast message_filters at runtime.
+///
+/// @invariant The backend is selected from use_agnocast() at construction and never
+///            changes, so the held subscriber object keeps a stable identity for the
+///            Subscriber's lifetime. subscribe() may therefore be called repeatedly
+///            without invalidating a Synchronizer already wired to this Subscriber.
 template <class M>
 class Subscriber
 {
 public:
-  Subscriber() = default;
+  using RclcppSubscriber = ::message_filters::Subscriber<M, rclcpp::Node>;
+  using AgnocastSubscriber = agnocast::message_filters::Subscriber<M, agnocast::Node>;
+
+  Subscriber()
+  : sub_(
+      use_agnocast() ? decltype(sub_)(std::in_place_type<AgnocastSubscriber>)
+                     : decltype(sub_)(std::in_place_type<RclcppSubscriber>))
+  {
+  }
 
   Subscriber(
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  : Subscriber()
   {
     subscribe(node, topic, qos);
   }
 
-  /// @note The backend mode is captured here and reused by unsubscribe().
-  ///       The wrapper Node's backend mode is fixed at construction and does not
-  ///       change for the lifetime of the Node, so the captured value remains valid.
   void subscribe(
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    const bool tmp_agnocast = node->is_using_agnocast();
-    if (tmp_agnocast) {
-      agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
-    } else {
-      rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
-    }
-    using_agnocast_ = tmp_agnocast;
+    std::visit(
+      [&](auto & sub) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(sub)>, AgnocastSubscriber>) {
+          sub.subscribe(node->get_agnocast_node().get(), topic, qos);
+        } else {
+          sub.subscribe(node->get_rclcpp_node().get(), topic, qos);
+        }
+      },
+      sub_);
   }
 
-  /// @note Uses the backend mode captured during the preceding subscribe() call.
-  ///       Calling this before subscribe() is a harmless no-op.
   void unsubscribe()
   {
-    if (using_agnocast_) {
-      agnocast_sub_.unsubscribe();
-    } else {
-      rclcpp_sub_.unsubscribe();
-    }
+    std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
 
   // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
-  ::message_filters::Subscriber<M, rclcpp::Node> & rclcpp_subscriber() { return rclcpp_sub_; }
-  agnocast::message_filters::Subscriber<M, agnocast::Node> & agnocast_subscriber()
-  {
-    return agnocast_sub_;
-  }
+  RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
+  AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
 
 private:
-  bool using_agnocast_ = false;
-  ::message_filters::Subscriber<M, rclcpp::Node> rclcpp_sub_;
-  agnocast::message_filters::Subscriber<M, agnocast::Node> agnocast_sub_;
+  std::variant<RclcppSubscriber, AgnocastSubscriber> sub_;
 };
 
 /// @brief Wrapper ApproximateTime Synchronizer that switches between
@@ -133,24 +137,34 @@ public:
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
 
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  : sync_(
+      use_agnocast() ? decltype(sync_)(
+                         std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
+                         sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
+                     : decltype(sync_)(
+                         std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
+                         sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
   {
-    if (use_agnocast()) {
-      agnocast_sync_ = std::make_unique<AgnocastSync>(
-        AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber());
-    } else {
-      rclcpp_sync_ = std::make_unique<RclcppSync>(
-        RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber());
-    }
   }
+
+  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
+  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
+  ApproximateTimeSynchronizer(ApproximateTimeSynchronizer &&) = delete;
+  ApproximateTimeSynchronizer & operator=(ApproximateTimeSynchronizer &&) = delete;
 
   void registerCallback(Callback callback)
   {
     stored_callback_ = std::move(callback);
-    if (use_agnocast()) {
-      agnocast_sync_->registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
-    } else {
-      rclcpp_sync_->registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
-    }
+    std::visit(
+      [this](auto & sync) {
+        using SyncT = std::decay_t<decltype(sync)>;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          sync.registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
+        } else {
+          sync.registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
+        }
+      },
+      sync_);
   }
 
 private:
@@ -179,11 +193,11 @@ private:
 
   using RclcppPolicy = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-  std::unique_ptr<RclcppSync> rclcpp_sync_;
 
   using AgnocastPolicy = agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
-  std::unique_ptr<AgnocastSync> agnocast_sync_;
+
+  std::variant<RclcppSync, AgnocastSync> sync_;
 };
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -22,12 +22,15 @@
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/synchronizer.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #ifdef USE_AGNOCAST_ENABLED
 
@@ -90,7 +93,7 @@ public:
     std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
 
-  // Internal API: used by ApproximateTimeSynchronizer / ExactTimeSynchronizer.
+  // Internal API: used by PolicySynchronizer.
   // Not intended for downstream use.
   RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
   AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
@@ -100,7 +103,8 @@ private:
 };
 
 /// @brief Common synchronizer wrapper parameterized by the underlying policy types.
-///        Use through ApproximateTimeSynchronizer or ExactTimeSynchronizer.
+///        Use through the user-facing Synchronizer<sync_policies::ApproximateTime<M0, M1>> /
+///        Synchronizer<sync_policies::ExactTime<M0, M1>>.
 ///
 /// At construction, use_agnocast() selects which backend synchronizer to instantiate
 /// inside the internal std::variant; the choice is fixed for the wrapper's lifetime
@@ -133,104 +137,150 @@ public:
   {
   }
 
-  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
-  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
+  // Non-copyable and non-movable: upstream holds raw pointers into this object
+  // (see CallbackAdapter), so its address must stay stable for the registrations' lifetime.
+  ~PolicySynchronizer() = default;
+  PolicySynchronizer(const PolicySynchronizer &) = delete;
+  PolicySynchronizer & operator=(const PolicySynchronizer &) = delete;
   PolicySynchronizer(PolicySynchronizer &&) = delete;
   PolicySynchronizer & operator=(PolicySynchronizer &&) = delete;
 
-  void registerCallback(Callback callback)
+  /// @brief Register a callable for each matching tuple. Mirrors the four upstream
+  ///        `::message_filters::Synchronizer::registerCallback` overloads (free callable
+  ///        or member-fn-ptr + instance; const and non-const).
+  ///
+  /// Signature: `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
+  ///                  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
+  /// Returns `::message_filters::Connection` whose `.disconnect()` removes THIS callable
+  /// only (not RAII — scope exit does NOT unregister).
+  ///
+  /// @note Multiple callables can be registered; all fire on each matching tuple. Dispatch
+  ///       is delegated to the underlying rclcpp/agnocast synchronizer, so ordering and
+  ///       concurrency semantics match upstream.
+  /// @note The returned Connection captures `this`; do not invoke `.disconnect()` after
+  ///       this Synchronizer has been destroyed. Mirrors upstream
+  ///       `::message_filters::Synchronizer`, whose Connection has the same lifetime contract.
+  template <class C>
+  ::message_filters::Connection registerCallback(C & callback)
   {
-    stored_callback_ = std::move(callback);
-    std::visit(
-      [this](auto & sync) {
-        using SyncT = std::decay_t<decltype(sync)>;
-        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
-        } else {
-          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
-        }
-      },
-      sync_);
+    return registerCallbackInternal(Callback(callback));
+  }
+
+  template <class C>
+  ::message_filters::Connection registerCallback(const C & callback)
+  {
+    return registerCallbackInternal(Callback(callback));
+  }
+
+  template <class C, typename T>
+  ::message_filters::Connection registerCallback(C & callback, T * t)
+  {
+    return registerCallbackInternal(bindMemberCallback(callback, t));
+  }
+
+  template <class C, typename T>
+  ::message_filters::Connection registerCallback(const C & callback, T * t)
+  {
+    return registerCallbackInternal(bindMemberCallback(callback, t));
   }
 
 private:
-  Callback stored_callback_;
-
-  using M0Event = agnocast::message_filters::MessageEvent<const M0>;
-  using M1Event = agnocast::message_filters::MessageEvent<const M1>;
-
-  void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
+  // Per-registration adapter: owns the user callable and bridges upstream's MessageEvent /
+  // ConstSharedPtr arguments to the wrapper's message_ptr type. Upstream keeps only a raw
+  // pointer (adapter.get()), so it is held in `adapters_` to keep it alive.
+  struct CallbackAdapter
   {
-    // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
-    const auto p0 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
-    const auto p1 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
-    stored_callback_(p0, p1);
-  }
+    Callback fn;
 
-  void rclcppCallbackAdapter(
-    const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
-  {
-    const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
-    const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
-    stored_callback_(p0, p1);
-  }
+    using M0Event = agnocast::message_filters::MessageEvent<const M0>;
+    using M1Event = agnocast::message_filters::MessageEvent<const M1>;
 
+    void agnocastInvoke(const M0Event & e0, const M1Event & e1)
+    {
+      // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
+      const auto p0 =
+        AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
+      const auto p1 =
+        AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
+      fn(p0, p1);
+    }
+
+    void rclcppInvoke(
+      const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
+    {
+      const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
+      const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
+      fn(p0, p1);
+    }
+  };
+
+  using AdapterPtr = std::unique_ptr<CallbackAdapter>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
+  template <class C, typename T>
+  static Callback bindMemberCallback(C && callback, T * t)
+  {
+    return Callback{
+      [callback = std::forward<C>(callback), t](
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) & m0,
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) & m1) { (t->*callback)(m0, m1); }};
+  }
+
+  ::message_filters::Connection registerCallbackInternal(Callback && callback)
+  {
+    auto adapter = std::make_unique<CallbackAdapter>();
+    adapter->fn = std::move(callback);
+    auto * const adapter_raw = adapter.get();
+
+    auto upstream_conn = std::visit(
+      [adapter_raw](auto & sync) -> ::message_filters::Connection {
+        using SyncT = std::decay_t<decltype(sync)>;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          return sync.registerCallback(&CallbackAdapter::agnocastInvoke, adapter_raw);
+        } else {
+          return sync.registerCallback(&CallbackAdapter::rclcppInvoke, adapter_raw);
+        }
+      },
+      sync_);
+
+    // Upstream now holds `adapter_raw`; any throw before return would leave it
+    // dangling (Connection's dtor does not auto-disconnect). `upstream_conn` is
+    // copy-captured (not moved) so the catch handler still has a live local if
+    // the closure / Connection construction throws.
+    try {
+      {
+        std::lock_guard<std::mutex> lock(adapters_mutex_);
+        adapters_.push_back(std::move(adapter));
+      }
+
+      return ::message_filters::Connection(
+        ::message_filters::Connection::VoidDisconnectFunction(
+          [this, adapter_raw, upstream_conn]() mutable {
+            upstream_conn.disconnect();
+            std::lock_guard<std::mutex> lock(adapters_mutex_);
+            adapters_.erase(
+              std::remove_if(
+                adapters_.begin(), adapters_.end(),
+                [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
+              adapters_.end());
+          }));
+    } catch (...) {
+      upstream_conn.disconnect();
+      std::lock_guard<std::mutex> lock(adapters_mutex_);
+      adapters_.erase(
+        std::remove_if(
+          adapters_.begin(), adapters_.end(),
+          [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
+        adapters_.end());
+      throw;
+    }
+  }
+
+  std::mutex adapters_mutex_;
+  std::vector<AdapterPtr> adapters_;
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
-
-/// @brief Wrapper ApproximateTime Synchronizer that switches between
-///        rclcpp and agnocast message_filters at runtime.
-///
-/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
-///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
-/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
-/// preserving zero-copy semantics during the callback lifetime.
-///
-/// @note Current limitations:
-///   - Maximum 2 message types per Synchronizer.
-///   - connectInput() is not supported; pass Subscriber references at construction time.
-///
-/// @code
-/// using namespace autoware::agnocast_wrapper::message_filters;
-///
-/// Subscriber<sensor_msgs::msg::Image> image_sub;
-/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
-/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
-/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
-///
-/// using Policy = sync_policies::ApproximateTime<
-///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
-/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
-///
-/// sync->registerCallback(
-///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
-///
-/// // Where the callback method signature is:
-/// // void onSynchronized(
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
-/// @endcode
-template <typename M0, typename M1>
-using ApproximateTimeSynchronizer = PolicySynchronizer<
-  ::message_filters::sync_policies::ApproximateTime<M0, M1>,
-  agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
-
-/// @brief Wrapper ExactTime Synchronizer mirroring ApproximateTimeSynchronizer.
-///
-/// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
-/// only the sync policy differs (messages must share identical timestamps).
-/// @note Subject to the same limitations as ApproximateTimeSynchronizer
-///       (max 2 message types, connectInput() not supported).
-/// @see ApproximateTimeSynchronizer for a usage example.
-template <typename M0, typename M1>
-using ExactTimeSynchronizer = PolicySynchronizer<
-  ::message_filters::sync_policies::ExactTime<M0, M1>,
-  agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.
 ///        Allows node code to use the same pattern as rclcpp:
@@ -282,26 +332,75 @@ class Synchronizer
     "are supported. Policies with more than 2 message types are not implemented.");
 };
 
+/// @brief Synchronizer specialization for the wrapper-layer ApproximateTime policy.
+///        Switches between rclcpp and agnocast message_filters at runtime.
+///
+/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
+///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
+/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs, preserving
+/// zero-copy semantics during the callback lifetime.
+///
+/// @note Current limitations:
+///   - Maximum 2 message types per Synchronizer.
+///   - connectInput() is not supported; pass Subscriber references at construction time.
+///
+/// @code
+/// using namespace autoware::agnocast_wrapper::message_filters;
+///
+/// Subscriber<sensor_msgs::msg::Image> image_sub;
+/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
+/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
+/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
+///
+/// using Policy = sync_policies::ApproximateTime<
+///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
+/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
+///
+/// // Pass a member-function pointer and `this` (mirrors upstream message_filters):
+/// sync->registerCallback(&MyNode::onSynchronized, this);
+/// // Equivalent form (still supported):
+/// // sync->registerCallback(std::bind(
+/// //   &MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+/// @endcode
 template <typename M0, typename M1>
 class Synchronizer<sync_policies::ApproximateTime<M0, M1>>
-: public ApproximateTimeSynchronizer<M0, M1>
+: public PolicySynchronizer<
+    ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>
 {
+  using Base = PolicySynchronizer<
+    ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
+
 public:
   Synchronizer(
     const sync_policies::ApproximateTime<M0, M1> & policy, Subscriber<M0> & sub0,
     Subscriber<M1> & sub1)
-  : ApproximateTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  : Base(policy.queue_size, sub0, sub1)
   {
   }
 };
 
+/// @brief Synchronizer specialization for the wrapper-layer ExactTime policy.
+///
+/// Same callback signature and zero-copy semantics as the ApproximateTime specialization;
+/// only the sync policy differs (messages must share identical timestamps). Subject to the
+/// same limitations (max 2 message types, connectInput() not supported).
+/// @see Synchronizer<sync_policies::ApproximateTime<M0, M1>> for a usage example.
 template <typename M0, typename M1>
-class Synchronizer<sync_policies::ExactTime<M0, M1>> : public ExactTimeSynchronizer<M0, M1>
+class Synchronizer<sync_policies::ExactTime<M0, M1>>
+: public PolicySynchronizer<
+    ::message_filters::sync_policies::ExactTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>
 {
+  using Base = PolicySynchronizer<
+    ::message_filters::sync_policies::ExactTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
+
 public:
   Synchronizer(
     const sync_policies::ExactTime<M0, M1> & policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
-  : ExactTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  : Base(policy.queue_size, sub0, sub1)
   {
   }
 };
@@ -320,14 +419,6 @@ namespace message_filters
 
 template <class M>
 using Subscriber = ::message_filters::Subscriber<M>;
-
-template <typename M0, typename M1>
-using ApproximateTimeSynchronizer =
-  ::message_filters::Synchronizer<::message_filters::sync_policies::ApproximateTime<M0, M1>>;
-
-template <typename M0, typename M1>
-using ExactTimeSynchronizer =
-  ::message_filters::Synchronizer<::message_filters::sync_policies::ExactTime<M0, M1>>;
 
 namespace sync_policies
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -19,6 +19,7 @@
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/synchronizer.h>
 
 #include <functional>
@@ -32,6 +33,7 @@
 
 #include <agnocast/message_filters/subscriber.hpp>
 #include <agnocast/message_filters/sync_policies/approximate_time.hpp>
+#include <agnocast/message_filters/sync_policies/exact_time.hpp>
 #include <agnocast/message_filters/synchronizer.hpp>
 
 namespace autoware::agnocast_wrapper
@@ -88,7 +90,8 @@ public:
     std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
 
-  // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
+  // Internal API: used by ApproximateTimeSynchronizer / ExactTimeSynchronizer.
+  // Not intended for downstream use.
   RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
   AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
 
@@ -96,47 +99,30 @@ private:
   std::variant<RclcppSubscriber, AgnocastSubscriber> sub_;
 };
 
-/// @brief Wrapper ApproximateTime Synchronizer that switches between
-///        rclcpp and agnocast message_filters at runtime.
+/// @brief Common synchronizer wrapper parameterized by the underlying policy types.
+///        Use through ApproximateTimeSynchronizer or ExactTimeSynchronizer.
 ///
-/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
-///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
-/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
-/// preserving zero-copy semantics during the callback lifetime.
+/// At construction, use_agnocast() selects which backend synchronizer to instantiate
+/// inside the internal std::variant; the choice is fixed for the wrapper's lifetime
+/// and all subsequent calls (e.g. registerCallback) are dispatched via std::visit to
+/// the active backend. To add a third policy, instantiate this template with the
+/// corresponding rclcpp and agnocast policy types.
 ///
-/// @note Current limitations:
-///   - Only ApproximateTime synchronization policy is supported (no ExactTime).
-///   - Maximum 2 message types per Synchronizer.
-///   - connectInput() is not supported; pass Subscriber references at construction time.
-///
-/// @code
-/// using namespace autoware::agnocast_wrapper::message_filters;
-///
-/// Subscriber<sensor_msgs::msg::Image> image_sub;
-/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
-/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
-/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
-///
-/// using Policy = sync_policies::ApproximateTime<
-///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
-/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
-///
-/// sync->registerCallback(
-///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
-///
-/// // Where the callback method signature is:
-/// // void onSynchronized(
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
-/// @endcode
-template <typename M0, typename M1>
-class ApproximateTimeSynchronizer
+/// @tparam RclcppPolicy   ::message_filters sync policy type used when running on rclcpp
+///                        (e.g. ::message_filters::sync_policies::ApproximateTime<M0, M1>).
+/// @tparam AgnocastPolicy agnocast::message_filters sync policy type used when running on
+///                        agnocast (e.g. agnocast::message_filters::sync_policies::ExactTime<M0,
+///                        M1>).
+/// @tparam M0             First message type to synchronize.
+/// @tparam M1             Second message type to synchronize.
+template <typename RclcppPolicy, typename AgnocastPolicy, typename M0, typename M1>
+class PolicySynchronizer
 {
 public:
   using Callback = std::function<void(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
 
-  ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  PolicySynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   : sync_(
       use_agnocast() ? decltype(sync_)(
                          std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
@@ -149,8 +135,8 @@ public:
 
   // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
   // wrapper's address must remain stable for the lifetime of the internal synchronizer.
-  ApproximateTimeSynchronizer(ApproximateTimeSynchronizer &&) = delete;
-  ApproximateTimeSynchronizer & operator=(ApproximateTimeSynchronizer &&) = delete;
+  PolicySynchronizer(PolicySynchronizer &&) = delete;
+  PolicySynchronizer & operator=(PolicySynchronizer &&) = delete;
 
   void registerCallback(Callback callback)
   {
@@ -159,9 +145,9 @@ public:
       [this](auto & sync) {
         using SyncT = std::decay_t<decltype(sync)>;
         if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
+          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
         } else {
-          sync.registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
+          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
         }
       },
       sync_);
@@ -191,14 +177,60 @@ private:
     stored_callback_(p0, p1);
   }
 
-  using RclcppPolicy = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-
-  using AgnocastPolicy = agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
+
+/// @brief Wrapper ApproximateTime Synchronizer that switches between
+///        rclcpp and agnocast message_filters at runtime.
+///
+/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
+///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
+/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
+/// preserving zero-copy semantics during the callback lifetime.
+///
+/// @note Current limitations:
+///   - Maximum 2 message types per Synchronizer.
+///   - connectInput() is not supported; pass Subscriber references at construction time.
+///
+/// @code
+/// using namespace autoware::agnocast_wrapper::message_filters;
+///
+/// Subscriber<sensor_msgs::msg::Image> image_sub;
+/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
+/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
+/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
+///
+/// using Policy = sync_policies::ApproximateTime<
+///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
+/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
+///
+/// sync->registerCallback(
+///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+///
+/// // Where the callback method signature is:
+/// // void onSynchronized(
+/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
+/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
+/// @endcode
+template <typename M0, typename M1>
+using ApproximateTimeSynchronizer = PolicySynchronizer<
+  ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+  agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
+
+/// @brief Wrapper ExactTime Synchronizer mirroring ApproximateTimeSynchronizer.
+///
+/// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
+/// only the sync policy differs (messages must share identical timestamps).
+/// @note Subject to the same limitations as ApproximateTimeSynchronizer
+///       (max 2 message types, connectInput() not supported).
+/// @see ApproximateTimeSynchronizer for a usage example.
+template <typename M0, typename M1>
+using ExactTimeSynchronizer = PolicySynchronizer<
+  ::message_filters::sync_policies::ExactTime<M0, M1>,
+  agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.
 ///        Allows node code to use the same pattern as rclcpp:
@@ -207,22 +239,47 @@ private:
 ///          sync = std::make_shared<Sync>(SyncPolicy(10), sub0, sub1);
 namespace sync_policies
 {
+/// @brief Wrapper-layer ApproximateTime policy tag.
+///
+/// Carries only the queue size; the underlying rclcpp/agnocast policy is selected
+/// inside Synchronizer<ApproximateTime<M0, M1>>. Distinct from
+/// ::message_filters::sync_policies::ApproximateTime and
+/// agnocast::message_filters::sync_policies::ApproximateTime.
+///
+/// @tparam M0 First message type to synchronize.
+/// @tparam M1 Second message type to synchronize.
 template <typename M0, typename M1>
 struct ApproximateTime
 {
-  uint32_t queue_size;
-  explicit ApproximateTime(uint32_t qs) : queue_size(qs) {}
+  uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
+  explicit ApproximateTime(uint32_t qs) noexcept : queue_size(qs) {}
+};
+
+/// @brief Wrapper-layer ExactTime policy tag.
+///
+/// Carries only the queue size; the underlying rclcpp/agnocast policy is selected
+/// inside Synchronizer<ExactTime<M0, M1>>. Distinct from
+/// ::message_filters::sync_policies::ExactTime and
+/// agnocast::message_filters::sync_policies::ExactTime.
+///
+/// @tparam M0 First message type to synchronize.
+/// @tparam M1 Second message type to synchronize.
+template <typename M0, typename M1>
+struct ExactTime
+{
+  uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
+  explicit ExactTime(uint32_t qs) noexcept : queue_size(qs) {}
 };
 }  // namespace sync_policies
 
-/// @brief Primary Synchronizer template — only the ApproximateTime specialization is supported.
+/// @brief Primary Synchronizer template — supports ApproximateTime and ExactTime specializations.
 template <typename Policy>
 class Synchronizer
 {
   static_assert(
     sizeof(Policy) == 0,
-    "Only sync_policies::ApproximateTime<M0, M1> is supported. "
-    "ExactTime and policies with more than 2 message types are not implemented.");
+    "Only sync_policies::ApproximateTime<M0, M1> and sync_policies::ExactTime<M0, M1> "
+    "are supported. Policies with more than 2 message types are not implemented.");
 };
 
 template <typename M0, typename M1>
@@ -231,8 +288,20 @@ class Synchronizer<sync_policies::ApproximateTime<M0, M1>>
 {
 public:
   Synchronizer(
-    sync_policies::ApproximateTime<M0, M1> policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+    const sync_policies::ApproximateTime<M0, M1> & policy, Subscriber<M0> & sub0,
+    Subscriber<M1> & sub1)
   : ApproximateTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  {
+  }
+};
+
+template <typename M0, typename M1>
+class Synchronizer<sync_policies::ExactTime<M0, M1>> : public ExactTimeSynchronizer<M0, M1>
+{
+public:
+  Synchronizer(
+    const sync_policies::ExactTime<M0, M1> & policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  : ExactTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
   {
   }
 };
@@ -256,10 +325,16 @@ template <typename M0, typename M1>
 using ApproximateTimeSynchronizer =
   ::message_filters::Synchronizer<::message_filters::sync_policies::ApproximateTime<M0, M1>>;
 
+template <typename M0, typename M1>
+using ExactTimeSynchronizer =
+  ::message_filters::Synchronizer<::message_filters::sync_policies::ExactTime<M0, M1>>;
+
 namespace sync_policies
 {
 template <typename M0, typename M1>
 using ApproximateTime = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
+template <typename M0, typename M1>
+using ExactTime = ::message_filters::sync_policies::ExactTime<M0, M1>;
 }  // namespace sync_policies
 
 template <typename Policy>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -48,6 +48,13 @@ using OnSetParametersCallbackType =
 
 /// @brief Node wrapper class that can switch between rclcpp::Node and agnocast::Node at runtime
 /// based on the ENABLE_AGNOCAST environment variable.
+///
+/// @invariant The backend variant (rclcpp::Node or agnocast::Node) is chosen at construction
+///            and never mutates for the lifetime of the Node.
+/// @invariant `is_using_agnocast() == true`  iff `get_agnocast_node()` returns a valid
+///            shared_ptr without throwing.
+/// @invariant `is_using_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
+///            shared_ptr without throwing.
 class Node
 {
 public:
@@ -251,11 +258,14 @@ public:
   // ===== Internal node access (for Executor) =====
   // Callers must check is_using_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
+  // The return value is fixed for the lifetime of the Node (see class-level @invariant).
   bool is_using_agnocast() const
   {
     return std::holds_alternative<std::shared_ptr<agnocast::Node>>(node_);
   }
 
+  /// @pre `is_using_agnocast() == true`. Under this precondition, this method is guaranteed
+  ///      to return a valid non-null shared_ptr without throwing.
   /// @throws std::runtime_error if Agnocast is not enabled (check is_using_agnocast() first)
   std::shared_ptr<agnocast::Node> get_agnocast_node() const
   {
@@ -267,6 +277,8 @@ public:
       "Check is_using_agnocast() before calling this method.");
   }
 
+  /// @pre `is_using_agnocast() == false`. Under this precondition, this method is guaranteed
+  ///      to return a valid non-null shared_ptr without throwing.
   /// @throws std::runtime_error if the node is in agnocast mode (check !is_using_agnocast() first)
   std::shared_ptr<rclcpp::Node> get_rclcpp_node() const
   {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/version.h>
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -255,6 +256,24 @@ public:
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 
+  // ===== Timer =====
+  template <typename DurationRepT = int64_t, typename DurationT = std::milli, typename CallbackT>
+  Timer::SharedPtr create_wall_timer(
+    std::chrono::duration<DurationRepT, DurationT> period, CallbackT && callback,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return visit_node([&](auto & n) -> Timer::SharedPtr {
+      using NodeT = std::decay_t<decltype(*n)>;
+      if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
+        return std::make_shared<AgnocastTimer>(
+          n->create_wall_timer(period, std::forward<CallbackT>(callback), group));
+      } else {
+        return std::make_shared<ROS2Timer>(
+          n->create_wall_timer(period, std::forward<CallbackT>(callback), group));
+      }
+    });
+  }
+
   // ===== Internal node access (for Executor) =====
   // Callers must check use_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
@@ -311,6 +330,25 @@ std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
   return node->get_rclcpp_node();
 }
 
+/// @brief Create a timer driven by an explicit clock.
+///
+/// Provided as a free function rather than a Node member because
+/// rclcpp::Node::create_timer was added in Jazzy and does not exist on Humble;
+/// the free rclcpp::create_timer() is available on both. Mirrors the
+/// non-Agnocast-build overload so the same call site works in both builds.
+template <typename CallbackT>
+Timer::SharedPtr create_timer(
+  Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  if (use_agnocast()) {
+    return std::make_shared<AgnocastTimer>(agnocast::create_timer(
+      node->get_agnocast_node().get(), clock, period, std::forward<CallbackT>(callback), group));
+  }
+  return std::make_shared<ROS2Timer>(rclcpp::create_timer(
+    node->get_rclcpp_node().get(), clock, period, std::forward<CallbackT>(callback), group));
+}
+
 }  // namespace autoware::agnocast_wrapper
 
 #else
@@ -325,6 +363,19 @@ template <typename T>
 std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
 {
   return node;
+}
+
+/// @brief Create a timer driven by an explicit clock (non-Agnocast build).
+///
+/// Provided as a free function rather than a Node member because
+/// rclcpp::Node::create_timer was added in Jazzy and does not exist on Humble;
+/// the free rclcpp::create_timer() is available on both.
+template <typename CallbackT>
+rclcpp::TimerBase::SharedPtr create_timer(
+  Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  return rclcpp::create_timer(node, clock, period, std::forward<CallbackT>(callback), group);
 }
 
 }  // namespace autoware::agnocast_wrapper

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -50,10 +50,10 @@ using OnSetParametersCallbackType =
 /// based on the ENABLE_AGNOCAST environment variable.
 ///
 /// @invariant The backend variant (rclcpp::Node or agnocast::Node) is chosen at construction
-///            and never mutates for the lifetime of the Node.
-/// @invariant `is_using_agnocast() == true`  iff `get_agnocast_node()` returns a valid
+///            based on use_agnocast() and never mutates for the lifetime of the Node.
+/// @invariant `use_agnocast() == true`  iff `get_agnocast_node()` returns a valid
 ///            shared_ptr without throwing.
-/// @invariant `is_using_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
+/// @invariant `use_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
 ///            shared_ptr without throwing.
 class Node
 {
@@ -256,17 +256,13 @@ public:
   }
 
   // ===== Internal node access (for Executor) =====
-  // Callers must check is_using_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
+  // Callers must check use_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
   // The return value is fixed for the lifetime of the Node (see class-level @invariant).
-  bool is_using_agnocast() const
-  {
-    return std::holds_alternative<std::shared_ptr<agnocast::Node>>(node_);
-  }
 
-  /// @pre `is_using_agnocast() == true`. Under this precondition, this method is guaranteed
+  /// @pre `use_agnocast() == true`. Under this precondition, this method is guaranteed
   ///      to return a valid non-null shared_ptr without throwing.
-  /// @throws std::runtime_error if Agnocast is not enabled (check is_using_agnocast() first)
+  /// @throws std::runtime_error if Agnocast is not enabled (check use_agnocast() first)
   std::shared_ptr<agnocast::Node> get_agnocast_node() const
   {
     if (auto * p = std::get_if<std::shared_ptr<agnocast::Node>>(&node_)) {
@@ -274,12 +270,12 @@ public:
     }
     throw std::runtime_error(
       "get_agnocast_node() called but Agnocast is not enabled. "
-      "Check is_using_agnocast() before calling this method.");
+      "Check use_agnocast() before calling this method.");
   }
 
-  /// @pre `is_using_agnocast() == false`. Under this precondition, this method is guaranteed
+  /// @pre `use_agnocast() == false`. Under this precondition, this method is guaranteed
   ///      to return a valid non-null shared_ptr without throwing.
-  /// @throws std::runtime_error if the node is in agnocast mode (check !is_using_agnocast() first)
+  /// @throws std::runtime_error if the node is in agnocast mode (check !use_agnocast() first)
   std::shared_ptr<rclcpp::Node> get_rclcpp_node() const
   {
     if (auto * p = std::get_if<std::shared_ptr<rclcpp::Node>>(&node_)) {
@@ -287,7 +283,7 @@ public:
     }
     throw std::runtime_error(
       "get_rclcpp_node() called but the node is in agnocast mode. "
-      "Check !is_using_agnocast() before calling this method.");
+      "Check !use_agnocast() before calling this method.");
   }
 
 private:
@@ -308,7 +304,7 @@ private:
 };
 
 /// @brief Get the underlying rclcpp::Node from a node that inherits agnocast_wrapper::Node.
-/// @throws std::runtime_error if the node is in agnocast mode (check is_using_agnocast() first)
+/// @throws std::runtime_error if the node is in agnocast mode (check !use_agnocast() first)
 template <typename T>
 std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -1,0 +1,394 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+
+#include <rclcpp/qos.hpp>
+#include <tf2/buffer_core.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/qos.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <rclcpp/version.h>
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/tf2/buffer.hpp>
+#include <agnocast/node/tf2/static_transform_broadcaster.hpp>
+#include <agnocast/node/tf2/transform_broadcaster.hpp>
+#include <agnocast/node/tf2/transform_listener.hpp>
+
+namespace autoware::agnocast_wrapper
+{
+
+/// @brief Buffer alias — agnocast::Buffer here, tf2_ros::Buffer in the disabled build.
+///        Unlike the listener / broadcaster wrappers, there is no runtime dispatch; the
+///        choice is fixed at build time, and agnocast::Buffer omits APIs that would break
+///        under an AgnocastOnly executor (e.g. waitForTransform) so misuse fails to compile.
+// TODO(Koichi98): agnocast::Buffer currently does not implement waitForTransform, so it has no
+// dependency on the agnocast executor — that lets us alias it directly here, which surfaces
+// the AgnocastOnly-safety constraint at compile time (the async API simply does not exist
+// on the wrapper type). Once waitForTransform is added, this alias must become a
+// runtime-dispatched wrapper class.
+using Buffer = agnocast::Buffer;
+
+/// @brief Wrapper TransformListener that switches between tf2_ros and agnocast
+///        TransformListener implementations at runtime.
+///
+/// @invariant The backend is selected from use_agnocast() at construction and never
+///            changes, so the held impl's identity is stable for the wrapper's lifetime.
+///
+/// The node-taking constructors require a Method 2 node (autoware::agnocast_wrapper::Node)
+/// because an AgnocastOnly executor does not spin a plain tf2_ros::TransformListener; in
+/// Agnocast-enabled mode the agnocast backend must own the /tf subscription instead.
+/// See the README for a usage example.
+class TransformListener
+{
+public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::TransformListener>;
+  using AgnocastImpl = std::unique_ptr<agnocast::TransformListener>;
+
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
+  : impl_(
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_type<AgnocastImpl>,
+                         std::make_unique<agnocast::TransformListener>(
+                           buffer, *node.get_agnocast_node(), spin_thread, qos, static_qos))
+                     : decltype(impl_)(
+                         std::in_place_type<RclcppImpl>,
+                         std::make_unique<tf2_ros::TransformListener>(
+                           buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos)))
+  {
+  }
+
+  /// @brief Options-taking overload. Kept separate (not defaulted parameters) so the
+  ///        no-options ctor preserves each backend's own non-trivial option defaults.
+  ///        On the rclcpp path only the subset shared with agnocast::SubscriptionOptions
+  ///        is forwarded; other rclcpp fields stay at their rclcpp defaults.
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos, const AUTOWARE_SUBSCRIPTION_OPTIONS & options,
+    const AUTOWARE_SUBSCRIPTION_OPTIONS & static_options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformListener>(
+                                                buffer, *node.get_agnocast_node(), spin_thread, qos,
+                                                static_qos, options, static_options))
+        : [&] {
+            rclcpp::SubscriptionOptions ros2_options;
+            ros2_options.callback_group = options.callback_group;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+            ros2_options.ignore_local_publications = options.ignore_local_publications;
+            rclcpp::SubscriptionOptions ros2_static_options;
+            ros2_static_options.callback_group = static_options.callback_group;
+            ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
+            ros2_static_options.ignore_local_publications =
+              static_options.ignore_local_publications;
+            return decltype(impl_)(
+              std::in_place_type<RclcppImpl>,
+              std::make_unique<tf2_ros::TransformListener>(
+                buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos, ros2_options,
+                ros2_static_options));
+          }())
+  {
+  }
+
+  /// @brief Buffer-only constructor; the underlying listener creates its own node internally.
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
+  : impl_(
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_type<AgnocastImpl>,
+                         std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
+                     : decltype(impl_)(
+                         std::in_place_type<RclcppImpl>,
+                         std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
+  {
+  }
+
+  // Non-copyable and non-movable: matches the wrapped tf2_ros / agnocast types, which own
+  // subscriptions bound to the supplied node at construction.
+  TransformListener(const TransformListener &) = delete;
+  TransformListener & operator=(const TransformListener &) = delete;
+  TransformListener(TransformListener &&) = delete;
+  TransformListener & operator=(TransformListener &&) = delete;
+
+private:
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
+};
+
+/// @brief Wrapper TransformBroadcaster that switches between tf2_ros and agnocast
+///        TransformBroadcaster implementations at runtime.
+///
+/// Same backend-fixed-at-construction guarantee as TransformListener. Requires a
+/// Method 2 node so the agnocast backend can own the /tf publisher under an
+/// AgnocastOnly executor. sendTransform() dispatches via std::visit to the active impl.
+class TransformBroadcaster
+{
+public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::TransformBroadcaster>;
+  using AgnocastImpl = std::unique_ptr<agnocast::TransformBroadcaster>;
+
+  explicit TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::TransformBroadcaster>(*node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>,
+            std::make_unique<tf2_ros::TransformBroadcaster>(node.get_rclcpp_node().get(), qos)))
+  {
+  }
+
+  /// @brief Options-taking overload; same separate-overload rationale as TransformListener.
+  ///        Only qos_overriding_options crosses to the rclcpp side (the shared field).
+  TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformBroadcaster>(
+                                                *node.get_agnocast_node(), qos, options))
+        : [&] {
+            rclcpp::PublisherOptions ros2_options;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+            return decltype(impl_)(
+              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformBroadcaster>(
+                                                node.get_rclcpp_node().get(), qos, ros2_options));
+          }())
+  {
+  }
+
+  // Non-copyable and non-movable: matches the wrapped types, which own the /tf publisher
+  // bound to the supplied node at construction.
+  TransformBroadcaster(const TransformBroadcaster &) = delete;
+  TransformBroadcaster & operator=(const TransformBroadcaster &) = delete;
+  TransformBroadcaster(TransformBroadcaster &&) = delete;
+  TransformBroadcaster & operator=(TransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transform); }, impl_);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transforms); }, impl_);
+  }
+
+private:
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
+};
+
+/// @brief Wrapper StaticTransformBroadcaster mirroring TransformBroadcaster, but for
+///        /tf_static. Same backend-fixed-at-construction guarantee and Method-2-node
+///        requirement; the options-taking ctor has a Humble-specific intra-process tweak
+///        (see the inline comment on that branch).
+class StaticTransformBroadcaster
+{
+public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::StaticTransformBroadcaster>;
+  using AgnocastImpl = std::unique_ptr<agnocast::StaticTransformBroadcaster>;
+
+  explicit StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::StaticTransformBroadcaster>(*node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                              node.get_rclcpp_node().get(), qos)))
+  {
+  }
+
+  /// @brief Options-taking overload; same rationale as TransformBroadcaster's. Humble adds
+  ///        an intra-process tweak on the rclcpp side (see the #if branch below).
+  StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::StaticTransformBroadcaster>(
+              *node.get_agnocast_node(), qos, options))
+        : [&] {
+            rclcpp::PublisherOptions ros2_options;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+#if RCLCPP_VERSION_MAJOR < 28
+            // Humble: rclcpp intra-process doesn't support transient_local, so /tf_static needs
+            // it off. tf2_ros::StaticTransformBroadcaster did this in its default options
+            // pre-Jazzy; Jazzy (rclcpp 28+) removed it.
+            ros2_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+#endif
+            return decltype(impl_)(
+              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                                node.get_rclcpp_node().get(), qos, ros2_options));
+          }())
+  {
+  }
+
+  // Non-copyable and non-movable: matches the wrapped types, which own the /tf_static
+  // publisher bound to the supplied node at construction.
+  StaticTransformBroadcaster(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster & operator=(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster(StaticTransformBroadcaster &&) = delete;
+  StaticTransformBroadcaster & operator=(StaticTransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transform); }, impl_);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transforms); }, impl_);
+  }
+
+private:
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#else
+
+namespace autoware::agnocast_wrapper
+{
+
+// Agnocast-disabled build: thin composition wrappers over the tf2_ros types. Constructor
+// signatures match the agnocast-enabled build above.
+
+using Buffer = tf2_ros::Buffer;
+
+class TransformListener
+{
+public:
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
+  : impl_(buffer, &node, spin_thread, qos, static_qos)
+  {
+  }
+
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos, const AUTOWARE_SUBSCRIPTION_OPTIONS & options,
+    const AUTOWARE_SUBSCRIPTION_OPTIONS & static_options)
+  : impl_(buffer, &node, spin_thread, qos, static_qos, options, static_options)
+  {
+  }
+
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
+  : impl_(buffer, spin_thread)
+  {
+  }
+
+  TransformListener(const TransformListener &) = delete;
+  TransformListener & operator=(const TransformListener &) = delete;
+  TransformListener(TransformListener &&) = delete;
+  TransformListener & operator=(TransformListener &&) = delete;
+
+private:
+  tf2_ros::TransformListener impl_;
+};
+
+class TransformBroadcaster
+{
+public:
+  explicit TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
+  : impl_(&node, qos)
+  {
+  }
+
+  TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
+  : impl_(&node, qos, options)
+  {
+  }
+
+  TransformBroadcaster(const TransformBroadcaster &) = delete;
+  TransformBroadcaster & operator=(const TransformBroadcaster &) = delete;
+  TransformBroadcaster(TransformBroadcaster &&) = delete;
+  TransformBroadcaster & operator=(TransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    impl_.sendTransform(transform);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    impl_.sendTransform(transforms);
+  }
+
+private:
+  tf2_ros::TransformBroadcaster impl_;
+};
+
+class StaticTransformBroadcaster
+{
+public:
+  explicit StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
+  : impl_(&node, qos)
+  {
+  }
+
+  StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
+  : impl_(&node, qos, options)
+  {
+  }
+
+  StaticTransformBroadcaster(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster & operator=(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster(StaticTransformBroadcaster &&) = delete;
+  StaticTransformBroadcaster & operator=(StaticTransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    impl_.sendTransform(transform);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    impl_.sendTransform(transforms);
+  }
+
+private:
+  tf2_ros::StaticTransformBroadcaster impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#endif

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -15,7 +15,9 @@
 """Python equivalent of agnocast_env.launch.xml.
 
 Configuration:
-- Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
+- use_agnocast arg overrides the ENABLE_AGNOCAST environment variable per include
+  (set to "1" to enable). When not passed by the including launch file, it defaults to the
+  ENABLE_AGNOCAST environment variable (which itself defaults to "0").
 - Heaphook path is configurable via the agnocast_heaphook_path arg
   (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
@@ -36,7 +38,7 @@ from launch.substitutions import LaunchConfiguration
 
 
 def _resolve_agnocast_env(context):
-    use_agnocast = context.launch_configurations.get("use_agnocast", "0")
+    use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast"))
     use_multithread = context.perform_substitution(LaunchConfiguration("use_multithread"))
     heaphook_path = context.perform_substitution(LaunchConfiguration("agnocast_heaphook_path"))
     existing_ld_preload = context.perform_substitution(
@@ -76,9 +78,9 @@ def generate_launch_description():
                 "use_multithread",
                 default_value="false",
             ),
-            SetLaunchConfiguration(
+            DeclareLaunchArgument(
                 "use_agnocast",
-                EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
+                default_value=EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
             ),
             OpaqueFunction(function=_resolve_agnocast_env),
         ]

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -17,13 +17,15 @@
 Configuration:
 - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
 - Heaphook path is configurable via the agnocast_heaphook_path arg
-  (default: /opt/ros/humble/lib/libagnocast_heaphook.so)
+  (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
 Provides the following launch configurations:
 - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
 - container_package: resolved component container package name
 - container_executable: resolved component container executable name
 """
+
+import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -68,7 +70,7 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "agnocast_heaphook_path",
-                default_value="/opt/ros/humble/lib/libagnocast_heaphook.so",
+                default_value=f"/opt/ros/{os.environ.get('ROS_DISTRO', 'humble')}/lib/libagnocast_heaphook.so",
             ),
             DeclareLaunchArgument(
                 "use_multithread",

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -25,16 +25,25 @@ Provides the following launch configurations:
 - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
 - container_package: resolved component container package name
 - container_executable: resolved component container executable name
+
+Side effect (when ENABLE_AGNOCAST=1): emits exactly one
+``agnocast_discovery_agent`` per ``ros2 launch`` invocation. The actual spawn
+(and its tree-wide deduplication) lives in ``discovery_agent.launch.py``, which
+this file includes.
 """
 
 import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 
 
 def _resolve_agnocast_env(context):
@@ -83,5 +92,16 @@ def generate_launch_description():
                 default_value=EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
             ),
             OpaqueFunction(function=_resolve_agnocast_env),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("autoware_agnocast_wrapper"),
+                            "launch",
+                            "discovery_agent.launch.py",
+                        ]
+                    )
+                )
+            ),
         ]
     )

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -29,4 +29,13 @@
   <let name="container_executable" value="component_container_mt" if="$(eval &quot;'$(var use_agnocast)' != '1' and '$(var use_multithread)' == 'true'&quot;)"/>
   <let name="container_executable" value="agnocast_component_container" if="$(eval &quot;'$(var use_agnocast)' == '1' and '$(var use_multithread)' != 'true'&quot;)"/>
   <let name="container_executable" value="agnocast_component_container_cie" if="$(eval &quot;'$(var use_agnocast)' == '1' and '$(var use_multithread)' == 'true'&quot;)"/>
+
+  <!--
+    Spawn the per-IPC-namespace discovery agent (a singleton) when Agnocast is
+    enabled. This file is included once per agnocast-using node, so the spawn
+    and its tree-wide deduplication live in discovery_agent.launch.py, shared
+    with the Python wrapper. That file gates on ENABLE_AGNOCAST itself, so the
+    include is unconditional here.
+  -->
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/discovery_agent.launch.py"/>
 </launch>

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -2,7 +2,9 @@
 <launch>
   <!--
     Configuration:
-    - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
+    - use_agnocast arg overrides the ENABLE_AGNOCAST environment variable per include
+      (set to "1" to enable). When not passed by the including launch file, it defaults to the
+      ENABLE_AGNOCAST environment variable (which itself defaults to "0").
     - Heaphook path is configurable via the agnocast_heaphook_path arg
       (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
@@ -14,7 +16,7 @@
 
   <arg name="agnocast_heaphook_path" default="/opt/ros/$(env ROS_DISTRO humble)/lib/libagnocast_heaphook.so"/>
   <arg name="use_multithread" default="false"/>
-  <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
+  <arg name="use_agnocast" default="$(env ENABLE_AGNOCAST 0)"/>
 
   <!-- LD_PRELOAD -->
   <let name="ld_preload_value" value="$(var agnocast_heaphook_path):$(env LD_PRELOAD '')" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -4,7 +4,7 @@
     Configuration:
     - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
     - Heaphook path is configurable via the agnocast_heaphook_path arg
-      (default: /opt/ros/humble/lib/libagnocast_heaphook.so)
+      (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
     Provides the following variables:
     - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
@@ -12,7 +12,7 @@
     - container_executable: resolved component container executable name
   -->
 
-  <arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so"/>
+  <arg name="agnocast_heaphook_path" default="/opt/ros/$(env ROS_DISTRO humble)/lib/libagnocast_heaphook.so"/>
   <arg name="use_multithread" default="false"/>
   <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
 

--- a/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
@@ -1,0 +1,59 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spawn exactly one ``agnocast_discovery_agent`` per ``ros2 launch`` invocation.
+
+``agnocast_env.launch.{xml,py}`` is included once per agnocast-using node, but the
+discovery agent is a per-IPC-namespace singleton — one per launch tree is enough.
+Both wrappers include this file; the guard marker lives on the ``LaunchContext``
+*globals* so deduplication works across the whole launch tree, including the
+XML -> Python include boundary.
+
+Spawns only when ``ENABLE_AGNOCAST=1`` (read from the environment directly so it
+does not depend on the including scope). The agent's own ``flock(2)`` remains the
+cross-invocation safety net for separate ``ros2 launch`` runs against the same
+IPC namespace.
+"""
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch_ros.actions import Node
+
+# Marker key on the LaunchContext globals (tree-wide, not scope-local).
+_DISCOVERY_AGENT_SPAWNED_FLAG = "_agnocast_discovery_agent_spawned"
+
+
+def _spawn_once(context):
+    if os.environ.get("ENABLE_AGNOCAST", "0") != "1":
+        return []
+    if context.get_locals_as_dict().get(_DISCOVERY_AGENT_SPAWNED_FLAG):
+        return []
+    context.extend_globals({_DISCOVERY_AGENT_SPAWNED_FLAG: True})
+    return [
+        Node(
+            package="ros2agnocast_discovery_agent",
+            executable="discovery_agent",
+            name="agnocast_discovery_agent",
+            # Pin to root: which include wins the deduplication race is arbitrary,
+            # so without this the singleton would inherit some node's namespace.
+            namespace="/",
+            output="screen",
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=_spawn_once)])

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -25,7 +25,11 @@
   <depend>tf2_ros</depend>
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend condition="$ENABLE_AGNOCAST == 1">ros2agnocast_discovery_agent</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,10 +15,13 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
+  <depend>geometry_msgs</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
 

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,6 +15,7 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
+  <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>message_filters</depend>

--- a/common/autoware_agnocast_wrapper/test/test_discovery_agent_launch.py
+++ b/common/autoware_agnocast_wrapper/test/test_discovery_agent_launch.py
@@ -1,0 +1,69 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for discovery_agent.launch.py's tree-wide deduplication.
+
+These exercise the spawn helper against a real ``LaunchContext`` — no agent
+executable, kmod or ``ros2 launch`` is needed.
+"""
+
+# cspell:ignore delenv
+
+import importlib.util
+import os
+
+from launch import LaunchContext
+from launch_ros.actions import Node
+import pytest
+
+
+def _load():
+    path = os.path.join(os.path.dirname(__file__), "..", "launch", "discovery_agent.launch.py")
+    spec = importlib.util.spec_from_file_location("discovery_agent_launch", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load()
+
+
+def test_spawns_one_agent_per_launch_tree(mod, monkeypatch):
+    """Within one launch tree (shared context) only the first include spawns."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "1")
+    ctx = LaunchContext()
+    first = mod._spawn_once(ctx)
+    second = mod._spawn_once(ctx)
+    third = mod._spawn_once(ctx)
+    assert len(first) == 1
+    assert isinstance(first[0], Node)
+    assert second == []
+    assert third == []
+
+
+def test_separate_launch_trees_each_spawn(mod, monkeypatch):
+    """A fresh context (separate ros2 launch invocation) spawns again."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "1")
+    assert len(mod._spawn_once(LaunchContext())) == 1
+    assert len(mod._spawn_once(LaunchContext())) == 1
+
+
+def test_no_spawn_when_agnocast_disabled(mod, monkeypatch):
+    """Nothing is spawned unless ENABLE_AGNOCAST is exactly "1"."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "0")
+    assert mod._spawn_once(LaunchContext()) == []
+    monkeypatch.delenv("ENABLE_AGNOCAST", raising=False)
+    assert mod._spawn_once(LaunchContext()) == []


### PR DESCRIPTION
## Description  
 `autoware_agnocast_wrapper` 関連PRsをupstream (autowarefoundation/autoware_core) からcherry-pickします。wrapperでの機能追加のみで、既存APIの破壊的変更はしないので、このPRによる影響はありません。
後のperception nodesへのagnocast導入PRで、本PR導入機能を利用します。

### Cherry-picked PRs (in upstream merge order)

  | Upstream PR | Title |
  |---|---|
  | [#1078](https://github.com/autowarefoundation/autoware_core/pull/1078) | fix(autoware_agnocast_wrapper): fix message_filter subscriber to take `agnocast_wrapper::Node` |
  | [#1086](https://github.com/autowarefoundation/autoware_core/pull/1086) | refactor(autoware_agnocast_wrapper): to use `std::variant` in message_filter |
  | [#1037](https://github.com/autowarefoundation/autoware_core/pull/1037) | fix(autoware_agnocast_wrapper): refer to ROS_DISTRO for heaphook_path |
  | [#1085](https://github.com/autowarefoundation/autoware_core/pull/1085) | feat(autoware_agnocast_wrapper): introduce tf2 API |
  | [#1077](https://github.com/autowarefoundation/autoware_core/pull/1077) | feat(autoware_agnocast_wrapper): introduce `ExactTime` for message_filter |
  | [#1076](https://github.com/autowarefoundation/autoware_core/pull/1076) | feat(autoware_agnocast_wrapper): introduce Timer API |
  | [#1087](https://github.com/autowarefoundation/autoware_core/pull/1087) | feat(autoware_agnocast_wrapper): introduce diagnostic_updater API |
  | [#1091](https://github.com/autowarefoundation/autoware_core/pull/1091) | feat(autoware_agnocast_wrapper): align message_filters `registerCallback` with upstream API |
  | [#1121](https://github.com/autowarefoundation/autoware_core/pull/1121) | docs(autoware_agnocast_wrapper): update `autoware_agnocast_wrapper` review_guide.md |
  | [#1123](https://github.com/autowarefoundation/autoware_core/pull/1123) | feat(autoware_agnocast_wrapper): update `agnocast_env.launch` to enable override `use_agnocast` |
  | [#1084](https://github.com/autowarefoundation/autoware_core/pull/1084) | feat(autoware_agnocast_wrapper): spawn agnocast_discovery_agent from launch wrapper |

### Conflicts
`#1085` と `#1087` の cherry-pick 時に `CMakeLists.txt` / `package.xml` でコンフリクトが発生。いずれもこのブランチ既存の glog 依存（#88）と upstream 側の依存追加（tf2 / diagnostic_updater）が同じ箇所だったため、**両方の依存を残す形**で解決しました。



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
OSSにmergeする際に、`feat/v0.64/e2e-experiment-2026_06_04`に導入して動作確認済みです。

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
