### PR TITLE
fix(ndt_scan_matcher): explicitly include omp.h (#1166)

### DIFF
--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -58,6 +58,7 @@
 // cspell:ignore multigrid, nnvn, colj
 
 #include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
+#include <omp.h>
 
 #include <algorithm>
 #include <utility>


### PR DESCRIPTION
## Description

Cherry-pick of autowarefoundation/autoware_core#1166 into `feat/v0.64/e2e`.

Explicitly includes `omp.h` in `multigrid_ndt_omp_impl.hpp`, which uses OpenMP APIs but previously relied on transitive includes.

- Original commit: autowarefoundation/autoware_core@801be9de40889d564ce3164a4b4f4eecd76b826f
- Cherry-picked cleanly with no conflicts.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_core#1166

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.