### PR TITLE
fix(motion_utils): fix function calculate_stop_distance

### DIFF
--- a/common/autoware_motion_utils/src/distance/distance.cpp
+++ b/common/autoware_motion_utils/src/distance/distance.cpp
@@ -299,28 +299,28 @@ std::optional<double> calcDecelDistWithJerkAndAccConstraints(
 
   // Phase 2: jerk-limited braking
   // Calculate what the velocity (v2) would be exactly when the acceleration reaches acc_limit
-  const double v2 =
-    v1 + (negative_decel_limit * negative_decel_limit - a1 * a1) / (2.0 * negative_jerk_limit);
+  const double t_ramp = (negative_decel_limit - a1) / negative_jerk_limit;
+  const double v2 = v1 + a1 * t_ramp + 0.5 * negative_jerk_limit * t_ramp * t_ramp;
 
   if (v2 <= 0.0) {
     // The vehicle reaches v = 0 before hitting the maximum deceleration limit.
     // Solve for t where 0 = v1 + a1*t + 0.5*j*t^2
-    const double discriminant = a1 * a1 - 2.0 * jerk_limit * v1;
+    const double discriminant = a1 * a1 - 2.0 * negative_jerk_limit * v1;
 
     // should be impossible
     if (discriminant < 0.0) {
       return std::nullopt;
     }
 
-    const double t2 = -(a1 + std::sqrt(discriminant)) / jerk_limit;
-    const auto [x_stop, v_stop, a_stop] = update(x1, v1, a1, jerk_limit, t2);
+    const double t2 = (-a1 - std::sqrt(discriminant)) / negative_jerk_limit;
+    const auto [x_stop, v_stop, a_stop] = update(x1, v1, a1, negative_jerk_limit, t2);
 
     return std::max(0.0, x_stop);
   }
 
   // The vehicle successfully reaches the maximum deceleration limit.
-  const double t2 = (negative_decel_limit - a1) / jerk_limit;
-  const auto [x2, v2_final, a2_final] = update(x1, v1, a1, jerk_limit, t2);
+  const double t2 = (negative_decel_limit - a1) / negative_jerk_limit;
+  const auto [x2, v2_final, a2_final] = update(x1, v1, a1, negative_jerk_limit, t2);
 
   // Phase 3: Constant maximum deceleration
   // Decelerate at acc_limit from v2_final down to 0.


### PR DESCRIPTION
- fix incorrect jerk limit sign
- fix early-stop detection logic
- fix stopping math for accelerating vehicles

before:
<img width="1876" height="238" alt="Screenshot from 2026-06-15 17-18-47" src="https://github.com/user-attachments/assets/48e2c867-304d-4e2f-9fed-a178bbe0e1b6" />

after:
<img width="1876" height="238" alt="Screenshot from 2026-06-15 17-22-02" src="https://github.com/user-attachments/assets/0a3c3c82-ab92-48d3-8a16-83fe9b276b7b" />
