### PR TITLE
feat(motion_velocity_planner): apply autoware_agnocast_wrapper for CIE (cherry-pick #1187)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   DIRECTORY src
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_lib
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_lib
   PLUGIN "autoware::motion_velocity_planner::MotionVelocityPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_map_msgs</depend>


### PR DESCRIPTION
## Description

Cherry-pick of autowarefoundation/autoware_core#1187 into the tier4 e2e line (`feat/v0.64/e2e`).

Apply `CallbackIsolatedAgnocastExecutor` (CIE) to `autoware_motion_velocity_planner` by going through `autoware_agnocast_wrapper`. CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable: when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

**Motivation:** `motion_velocity_planner` used to be CIE-ized implicitly by running as a composable node inside the CIE container (`agnocast_component_container_cie`). On the e2e line it is now launched as a standalone `<node>` ([e2e diffusion planner launch](https://github.com/tier4/autoware_launch.x2/blob/d145c5f330749a619fd1623e4a6b58ac0b8afd69/autoware_launch/launch/e2e_components/diffusion_planner.launch.xml#L225)), so the standalone executable built via `rclcpp_components_register_node` runs on a plain `SingleThreadedExecutor` and is no longer CIE-ized (it shows up as a boundary non-CIE node in the CIE boundary measurement). This PR makes the standalone executable itself CIE-capable, restoring the isolation it previously had.

### Changes

- `CMakeLists.txt`: replace `rclcpp_components_register_node(...)` with `autoware_agnocast_wrapper_register_node(...)` (`ROS2_EXECUTOR SingleThreadedExecutor`, `AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor`).
- `package.xml`: add the `autoware_agnocast_wrapper` dependency.

No source changes. The node uses plain `rclcpp` publishers/subscriptions, so this only swaps the executor. Clean cherry-pick, no conflicts.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/968

**Upstream PR:**

- https://github.com/autowarefoundation/autoware_core/pull/1187

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all. The node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.
