### PR TITLE
fix(ndt_scan_matcher): explicitly include omp.h (#1166)

### DIFF
--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -58,6 +58,7 @@
 // cspell:ignore multigrid, nnvn, colj
 
 #include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
+#include <omp.h>
 
 #include <algorithm>
 #include <utility>


### PR DESCRIPTION
## Description

cherry-pick of this
- https://github.com/autowarefoundation/autoware_core/pull/1166

### Original PR Description


> ## Description
> 
> - Add explicit `#include <omp.h>` in `multigrid_ndt_omp_impl.hpp` to avoid build failure with `-DEIGEN_DONT_PARALLELIZE`.
> 
> - `multigrid_ndt_omp_impl.hpp` uses OpenMP APIs (`omp_get_max_threads()`, `omp_get_thread_num()`, `#pragma omp parallel for`) but did not explicitly include `<omp.h>`. The header was transitively included through Eigen's Core header, which includes `<omp.h>` only when both `_OPENMP` is defined and `EIGEN_DONT_PARALLELIZE` is not defined:
> 
> ```
>   // Eigen/Core
>   #if (defined _OPENMP) && (!defined EIGEN_DONT_PARALLELIZE)
>     #define EIGEN_HAS_OPENMP
>   #endif
>   #ifdef EIGEN_HAS_OPENMP
>   #include <omp.h>
>   #endif
> ```
> 
> - Building with `-DEIGEN_DONT_PARALLELIZE` may be appropriate for NDT because NDT manages its own thread-level parallelism over source point cloud iterations and should not rely on Eigen's internal OpenMP parallelization. However, this flag also prevents Eigen from including `<omp.h>`, causing a build failure.
>   - Note: whether `-DEIGEN_DONT_PARALLELIZE` should be applied to NDT requires further discussion. Regardless, the missing `#include <omp.h>` in `multigrid_ndt_omp_impl.hpp` is a latent bug — the file uses OpenMP APIs and must explicitly include their header rather than relying on a transitive include from Eigen.
> - This fix makes the dependency on `<omp.h>` explicit.
> 
> ### Build Error Message
> 
> ```
> colcon build --symlink-install --cmake-args \
>   -DCMAKE_BUILD_TYPE=Release \
>   -DBUILD_TESTING=Off \
>   -DCMAKE_CXX_FLAGS="-w -DEIGEN_DONT_PARALLELIZE"
> 
> 
> --- stderr: autoware_ndt_scan_matcher
> In file included from /home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp.cpp:15:
> /home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp: In constructor ‘pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform()’:
> /home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp:225:25: error: there are no arguments to ‘omp_get_max_threads’ that depend on a template parameter, so a declaration of ‘omp_get_max_threads’ must be available [-fpermissive]
>   225 |   params_.num_threads = omp_get_max_threads();
>       |                         ^~~~~~~~~~~~~~~~~~~
> ```
> 
> ## Related links
> 
> **Parent Issue:**
> 
> None
> 
> **Private Links:**
> 
> - [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780882292292139?thread_ts=1779929948.087319&cid=CRUE57C30)
> - [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780892744546649?thread_ts=1780482942.701449&cid=CRUE57C30)
