### PR TITLE
fix: avoid fixed node name for agnocast discovery agent

### DIFF
--- a/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
@@ -46,7 +46,6 @@ def _spawn_once(context):
         Node(
             package="ros2agnocast_discovery_agent",
             executable="discovery_agent",
-            name="agnocast_discovery_agent",
             # Pin to root: which include wins the deduplication race is arbitrary,
             # so without this the singleton would inherit some node's namespace.
             namespace="/",


### PR DESCRIPTION
## Description
autowareのマルチコンテナ化の起動に伴い、各Dockerコンテナでagnocast discovery agentを起動しているが、すべてのノードの名前が固定されているためduplicated検出されるため、名前の固定を解除する。

## Related links
チケット：https://tier4.atlassian.net/browse/T4DEV-55875


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
https://evaluation.ci.tier4.jp/evaluation/reports/154d03f5-0d53-57a9-9f4e-671d1c988079?project_id=x2_dev
をOTAして
```
ros2 topic echo /diagnostics | grep -A 12 -B 6 "Error: Duplicated nodes detected"
```
でduplicatedに表示されないのを確認。

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
